### PR TITLE
feat: sales return accounting, replacement items, and receipt status …

### DIFF
--- a/app/Http/Controllers/AppSettingController.php
+++ b/app/Http/Controllers/AppSettingController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AppSetting;
+use Illuminate\Http\Request;
+
+class AppSettingController extends Controller
+{
+    public function update(Request $request, string $key): \Illuminate\Http\JsonResponse
+    {
+        $request->validate(['value' => 'required']);
+
+        AppSetting::set($key, $request->value);
+
+        return response()->json([
+            'status'  => true,
+            'message' => 'Setting saved.',
+            'key'     => $key,
+            'value'   => $request->value,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Modules/SalesOrderController.php
+++ b/app/Http/Controllers/Modules/SalesOrderController.php
@@ -8,6 +8,7 @@ use App\Services\DropdownClass;
 use App\Services\PrintClass;
 use App\Traits\HandlesTransaction;
 use App\Http\Controllers\Controller;
+use App\Models\AppSetting;
 use App\Services\Modules\SalesOrderClass;
 use App\Http\Requests\Modules\SalesOrderRequest;
 
@@ -35,6 +36,9 @@ class SalesOrderController extends Controller
             case 'stock':
                 return $this->sales_order->stockAvailability();
             break;
+            case 'return-history':
+                return response()->json($this->sales_order->returnHistory($request));
+            break;
             default:
                 return inertia('Modules/Sales/Index', [
                     'dropdowns' => [
@@ -48,7 +52,7 @@ class SalesOrderController extends Controller
                         'sales_statuses' => $this->dropdown->sales_statuses(),
                     ],
                     'isExternal' => false,
-
+                    'return_grace_period' => (int) AppSetting::get('return_grace_period', 7),
                 ]);
             break;
         }
@@ -88,7 +92,7 @@ class SalesOrderController extends Controller
                     break;
                     case 'approve':
                         $request->merge(['id' => $id]);
-                        return $this->sales_order->approve($request->id, $request->item_ids ?? []);
+                        return $this->sales_order->approve($request->id, $request->item_ids ?? [], $request->replacement_items ?? []);
                     break;
                     case 'adjustment':
                         $request->merge(['id' => $id]);

--- a/app/Http/Requests/Modules/RemittanceRequest.php
+++ b/app/Http/Requests/Modules/RemittanceRequest.php
@@ -24,7 +24,6 @@ class RemittanceRequest extends FormRequest
         return [
             'receipts' => 'required|array|min:1',
             'receipts.*' => 'integer|exists:receipts,id',
-            'remittance_type' => 'required|in:cash,credit',
             'summary' => 'required|array',
             'total_amount' => 'required|numeric|min:0',
         ];

--- a/app/Http/Resources/Libraries/ReceiptResource.php
+++ b/app/Http/Resources/Libraries/ReceiptResource.php
@@ -79,6 +79,7 @@ class ReceiptResource extends JsonResource
                             'product_id' => $item->product_id,
                             'product_name' => $item->relationLoaded('product') ? optional($item->product)->name : null,
                             'quantity' => $item->quantity,
+                            'returned_quantity' => (int) ($item->returned_quantity ?? 0),
                             'price' => $item->price,
                             'price_type' => $item->price_type,
                             'batch_code' => $item->batch_code,

--- a/app/Http/Resources/Modules/SalesOrderResource.php
+++ b/app/Http/Resources/Modules/SalesOrderResource.php
@@ -35,7 +35,20 @@ class SalesOrderResource extends JsonResource
             'due_date_raw' => $this->due_date?->format('Y-m-d'),
             'transferred_to' => $this->transferred_to,
             'transferred_at' => $this->transferred_at,
-            'items' => $this->items,
+            'location' => $this->location ? ['id' => $this->location->id, 'name' => $this->location->name] : null,
+            'approved_by_user' => $this->approved_by ? ($this->approved_by->employee ? $this->approved_by->employee->full_name ?? $this->approved_by->name : $this->approved_by->name) : null,
+            'approved_at' => $this->approved_at?->format('M d, Y'),
+            'items' => $this->items->map(fn($item) => [
+                'id'                 => $item->id,
+                'product_id'         => $item->product_id,
+                'product_name'       => $item->product?->name,
+                'quantity'           => $item->quantity,
+                'returned_quantity'  => (int) ($item->returned_quantity ?? 0),
+                'price'              => $item->price,
+                'discount_per_unit'  => $item->discount_per_unit ?? 0,
+                'unit'               => $item->unit,
+                'batch_code'         => $item->batch_code,
+            ])->values(),
             'return_item_ids' => $returnItems
                 ->pluck('sales_order_item_id')
                 ->map(fn ($id) => (int) $id)
@@ -65,6 +78,15 @@ class SalesOrderResource extends JsonResource
             'created_at' => $this->created_at->format('M d, Y'),
             'updated_at' => $this->updated_at?->format('M d, Y'),
             'approved_by' => $this->approved_by,
+            'return_replacements' => $this->returnReplacements->map(fn($r) => [
+                'id'          => $r->id,
+                'product_id'  => $r->product_id,
+                'product_name'=> $r->product?->name,
+                'quantity'    => $r->quantity,
+                'price'       => $r->price,
+                'total_value' => $r->total_value,
+                'replaced_at' => $r->replaced_at,
+            ])->values(),
         ];
     }
 }

--- a/app/Models/AppSetting.php
+++ b/app/Models/AppSetting.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AppSetting extends Model
+{
+    protected $table = 'app_settings';
+    protected $fillable = ['key', 'value'];
+
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $record = static::where('key', $key)->first();
+        return $record ? $record->value : $default;
+    }
+
+    public static function set(string $key, mixed $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => (string) $value]);
+    }
+}

--- a/app/Models/Receipt.php
+++ b/app/Models/Receipt.php
@@ -19,6 +19,7 @@ class Receipt extends Model
         'ar_invoice_id',
         'source_receipt_id',
         'remittance_id',
+        'notes',
     ];
 
     public function arInvoice()

--- a/app/Models/SalesOrder.php
+++ b/app/Models/SalesOrder.php
@@ -96,6 +96,11 @@ class SalesOrder extends Model
         return $this->hasMany(ArInvoice::class);
     }
 
+    public function returnReplacements()
+    {
+        return $this->hasMany(\App\Models\SalesReturnReplacement::class);
+    }
+
     public static function generateSoNumber($date = null, $prefix = 'SO')
     {
         $date = $date ?: now();

--- a/app/Models/SalesReturnHistory.php
+++ b/app/Models/SalesReturnHistory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SalesReturnHistory extends Model
+{
+    protected $table = 'sales_return_history';
+
+    protected $fillable = [
+        'sales_order_id',
+        'sales_order_item_id',
+        'product_id',
+        'quantity',
+        'condition',
+        'unit_price',
+        'total_value',
+        'returned_at',
+        'approved_by_id',
+    ];
+
+    protected $casts = [
+        'returned_at' => 'date',
+    ];
+
+    public function salesOrder()
+    {
+        return $this->belongsTo(SalesOrder::class, 'sales_order_id');
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class, 'product_id');
+    }
+
+    public function approvedBy()
+    {
+        return $this->belongsTo(User::class, 'approved_by_id');
+    }
+}

--- a/app/Models/SalesReturnReplacement.php
+++ b/app/Models/SalesReturnReplacement.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SalesReturnReplacement extends Model
+{
+    protected $table = 'sales_return_replacements';
+    protected $fillable = ['sales_order_id', 'product_id', 'quantity', 'price', 'total_value', 'replaced_at', 'replaced_by_id'];
+
+    public function product()  { return $this->belongsTo(Product::class); }
+    public function salesOrder() { return $this->belongsTo(SalesOrder::class); }
+    public function replacedBy() { return $this->belongsTo(User::class, 'replaced_by_id'); }
+}

--- a/app/Services/Accounting/JournalEntryService.php
+++ b/app/Services/Accounting/JournalEntryService.php
@@ -298,6 +298,64 @@ class JournalEntryService
         return $entries;
     }
 
+    public function recordReplacementEntries(SalesOrder $salesOrder, array $replacementItems, ?Receipt $extraReceipt = null): array
+    {
+        $entries = [];
+
+        $replacementCost = round(array_sum(array_map(function ($item) {
+            $productId = (int) ($item['product_id'] ?? 0);
+            $quantity  = (int) ($item['quantity']   ?? 0);
+            if ($productId <= 0 || $quantity <= 0) {
+                return 0;
+            }
+            $stock = InventoryStocks::where(function ($q) use ($productId) {
+                $q->whereHas('receivedItem', fn ($s) => $s->where('product_id', $productId))
+                  ->orWhere(fn ($s) => $s->where('product_id', $productId)->whereNotNull('conversion_id'));
+            })->orderBy('created_at')->first();
+
+            $unitCost = (float) ($stock?->receivedItem?->unit_cost ?? $stock?->unit_cost ?? 0);
+
+            return $unitCost * $quantity;
+        }, $replacementItems)), 2);
+
+        if ($replacementCost > 0) {
+            $cogsAccount      = $this->ensureAccount('5100', 'cost_of_goods_sold', 'Cost of Goods Sold', 'expense', 'cost_of_sales');
+            $inventoryAccount = $this->ensureAccount('1200', 'rice_inventory', 'Rice Inventory', 'asset', 'inventory');
+            $memo = 'Replacement goods issued for SO#' . $salesOrder->so_number . '. Inventory reduction entry.';
+
+            $entries[] = $this->createEntry(
+                $salesOrder,
+                now()->toDateString(),
+                'replacement_inventory_out',
+                $memo,
+                [
+                    [
+                        'account_id'  => $cogsAccount->id,
+                        'line_type'   => 'debit',
+                        'amount'      => $replacementCost,
+                        'description' => 'Cost of replacement goods issued to customer.',
+                    ],
+                    [
+                        'account_id'  => $inventoryAccount->id,
+                        'line_type'   => 'credit',
+                        'amount'      => $replacementCost,
+                        'description' => 'Reduce inventory for replacement goods issued.',
+                    ],
+                ],
+                $memo
+            );
+        }
+
+        if ($extraReceipt) {
+            $entry = $this->recordReceiptEntry($extraReceipt);
+            if ($entry) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
+    }
+
     public function recordReplenishmentEntry(\App\Models\ReplenishmentRequest $replenishment): ?JournalEntry
     {
         $expenses = $replenishment->expenses;

--- a/app/Services/DropdownClass.php
+++ b/app/Services/DropdownClass.php
@@ -137,10 +137,18 @@ class DropdownClass
         $data = Product::with(['brand', 'unit'])->get()->map(function ($item) {
             $batchStocks = InventoryStocks::query()
                 ->with('receivedItem')
-                ->whereHas('receivedItem', function ($query) use ($item) {
-                    $query->where('product_id', $item->id);
-                })
                 ->where('quantity', '>', 0)
+                ->where(function ($q) use ($item) {
+                    // Received stocks (linked via received_item)
+                    $q->whereHas('receivedItem', function ($sub) use ($item) {
+                        $sub->where('product_id', $item->id);
+                    })
+                    // Converted stocks (product_id set directly on the row)
+                    ->orWhere(function ($sub) use ($item) {
+                        $sub->where('product_id', $item->id)
+                            ->whereNotNull('conversion_id');
+                    });
+                })
                 ->orderBy('created_at')
                 ->get();
 
@@ -156,7 +164,7 @@ class DropdownClass
                 return [
                     'batch_code' => $batchCode,
                     'quantity' => (int) $stocks->sum('quantity'),
-                    'unit_cost' => $firstStock?->receivedItem?->unit_cost,
+                    'unit_cost' => $firstStock?->receivedItem?->unit_cost ?? $firstStock?->unit_cost,
                     'retail_price' => $firstStock?->retail_price,
                     'wholesale_price' => $firstStock?->wholesale_price,
                 ];
@@ -170,10 +178,16 @@ class DropdownClass
                 $batch_available = $batch_stocks[0]['quantity'];
                 $firstInventoryStock = InventoryStocks::query()
                     ->where('batch_code', $batch_code)
-                    ->whereHas('receivedItem', function ($query) use ($item) {
-                        $query->where('product_id', $item->id);
-                    })
                     ->where('quantity', '>', 0)
+                    ->where(function ($q) use ($item) {
+                        $q->whereHas('receivedItem', function ($sub) use ($item) {
+                            $sub->where('product_id', $item->id);
+                        })
+                        ->orWhere(function ($sub) use ($item) {
+                            $sub->where('product_id', $item->id)
+                                ->whereNotNull('conversion_id');
+                        });
+                    })
                     ->orderBy('created_at')
                     ->first();
             }

--- a/app/Services/Libraries/ReceiptClass.php
+++ b/app/Services/Libraries/ReceiptClass.php
@@ -118,23 +118,30 @@ class ReceiptClass
 
             $salesOrder = $arInvoice->sales_order;
             if ($salesOrder) {
+                $salesOrder->loadMissing('status');
+                $currentSlug       = $salesOrder->status?->slug ?? '';
+                $isFullyReturned   = ($currentSlug === 'sales-returned');
+                $isPartialReturned = ($currentSlug === 'partially-returned');
+
                 if ($arInvoice->balance_due <= 0) {
-                    $salesOrder->update(['status_id' => ListStatus::getBySlug('closed')?->id]);
+                    if (!$isFullyReturned) {
+                        $salesOrder->update(['status_id' => ListStatus::getBySlug('closed')?->id]);
 
-                    if (!SalesOrderIncentive::where('sales_order_id', $salesOrder->id)->exists()) {
-                        $sold_quantity    = $salesOrder->items->sum('quantity');
-                        $product_total_kg = $salesOrder->items->sum(fn($item) => ($item->product->weight ?? 0) * $item->quantity);
+                        if ($salesOrder->sales_rep_id && !SalesOrderIncentive::where('sales_order_id', $salesOrder->id)->exists()) {
+                            $sold_quantity    = $salesOrder->items->sum('quantity');
+                            $product_total_kg = $salesOrder->items->sum(fn($item) => ($item->product->weight ?? 0) * $item->quantity);
 
-                        SalesOrderIncentive::create([
-                            'sales_order_id'   => $salesOrder->id,
-                            'employee_id'      => $salesOrder->sales_rep_id,
-                            'sold_quantity'    => $sold_quantity,
-                            'product_total_kg' => $product_total_kg,
-                            'amount'           => $product_total_kg / 25,
-                            'payroll_id'       => null,
-                        ]);
+                            SalesOrderIncentive::create([
+                                'sales_order_id'   => $salesOrder->id,
+                                'employee_id'      => $salesOrder->sales_rep_id,
+                                'sold_quantity'    => $sold_quantity,
+                                'product_total_kg' => $product_total_kg,
+                                'amount'           => $product_total_kg / 25,
+                                'payroll_id'       => null,
+                            ]);
+                        }
                     }
-                } else {
+                } elseif (!$isFullyReturned && !$isPartialReturned) {
                     $salesOrder->update(['status_id' => ListStatus::getBySlug('partially-paid')?->id]);
                 }
             }
@@ -176,12 +183,21 @@ class ReceiptClass
 
         $salesOrder = $arInvoice->sales_order;
         if ($salesOrder) {
+            $salesOrder->loadMissing('status');
+            $currentSlug       = $salesOrder->status?->slug ?? '';
+            $isFullyReturned   = ($currentSlug === 'sales-returned');
+            $isPartialReturned = ($currentSlug === 'partially-returned');
+
             if ($arInvoice->balance_due <= 0) {
-                $salesOrder->update(['status_id' => ListStatus::getBySlug('closed')?->id]);
-            } elseif ($arInvoice->amount_paid > 0) {
-                $salesOrder->update(['status_id' => ListStatus::getBySlug('partially-paid')?->id]);
-            } else {
-                $salesOrder->update(['status_id' => ListStatus::getBySlug('for-payment')?->id]);
+                if (!$isFullyReturned) {
+                    $salesOrder->update(['status_id' => ListStatus::getBySlug('closed')?->id]);
+                }
+            } elseif (!$isFullyReturned && !$isPartialReturned) {
+                if ($arInvoice->amount_paid > 0) {
+                    $salesOrder->update(['status_id' => ListStatus::getBySlug('partially-paid')?->id]);
+                } else {
+                    $salesOrder->update(['status_id' => ListStatus::getBySlug('for-payment')?->id]);
+                }
             }
         }
 
@@ -221,10 +237,16 @@ class ReceiptClass
         // Bug 5 fix: sync SO status after reversing the payment
         $salesOrder = $arInvoice->sales_order;
         if ($salesOrder) {
-            if ($arInvoice->amount_paid <= 0) {
-                $salesOrder->update(['status_id' => ListStatus::getBySlug('for-payment')?->id]);
-            } else {
-                $salesOrder->update(['status_id' => ListStatus::getBySlug('partially-paid')?->id]);
+            $salesOrder->loadMissing('status');
+            $currentSlug    = $salesOrder->status?->slug ?? '';
+            $isReturnStatus = in_array($currentSlug, ['partially-returned', 'sales-returned']);
+
+            if (!$isReturnStatus) {
+                if ($arInvoice->amount_paid <= 0) {
+                    $salesOrder->update(['status_id' => ListStatus::getBySlug('for-payment')?->id]);
+                } else {
+                    $salesOrder->update(['status_id' => ListStatus::getBySlug('partially-paid')?->id]);
+                }
             }
         }
 

--- a/app/Services/Modules/ProductConversionService.php
+++ b/app/Services/Modules/ProductConversionService.php
@@ -53,7 +53,7 @@ class ProductConversionService
             ]);
         }
 
-        $newBatchCode = $this->series->get('batch_code');
+        $newBatchCode = $this->series->get('batch_code') . '-Con';
 
         // Use frontend-computed unit cost if provided, otherwise derive from source
         $sourceUnitCost = floatval($source->receivedItem?->unit_cost ?? $source->unit_cost ?? 0);

--- a/app/Services/Modules/RemittanceClass.php
+++ b/app/Services/Modules/RemittanceClass.php
@@ -177,8 +177,8 @@ class RemittanceClass
         try {
             $data = Remittance::with('status')->findOrFail($id);
 
-            if ($data->status?->slug !== 'remitted') {
-                throw new \Exception('Only remitted remittances can be approved or disapproved.');
+            if (!in_array($data->status?->slug, ['open', 'remitted'])) {
+                throw new \Exception('Only open remittances can be approved or disapproved.');
             }
 
             $isApprove = $request->status === 'Approve';

--- a/app/Services/Modules/SalesOrderClass.php
+++ b/app/Services/Modules/SalesOrderClass.php
@@ -17,6 +17,8 @@ use App\Models\ReceivedItem;
 use App\Models\Product;
 use App\Models\ListStatus;
 use App\Models\InventoryAdjustment;
+use App\Models\SalesReturnHistory;
+use App\Models\AppSetting;
 use App\Http\Resources\Modules\SalesOrderResource;
 use App\Services\Accounting\JournalEntryService;
 use App\Services\Modules\InventoryService;
@@ -26,7 +28,7 @@ class SalesOrderClass
 {
     public static function returnWindowDays(): int
     {
-        return (int) env('SALES_RETURN_WINDOW_DAYS', 7);
+        return (int) AppSetting::get('return_grace_period', env('SALES_RETURN_WINDOW_DAYS', 7));
     }
 
     protected $inventoryService;
@@ -39,20 +41,24 @@ class SalesOrderClass
     }
 
     public function lists($request){
-        $returnStatuses = ['sales-returned', 'sales-return-approval'];
+        $returnStatuses = ['sales-returned', 'sales-return-approval', 'partially-returned'];
         $requestedStatuses = is_array($request->status) ? $request->status : [$request->status];
         $requestedStatuses = array_values(array_filter($requestedStatuses));
         $includesReturnStatuses = count(array_intersect($requestedStatuses, $returnStatuses)) > 0;
 
         $query = SalesOrder::with([
             'items.salesReturnItems',
+            'items.product',
             'arInvoices.receipts.status',
             'customer',
             'status',
             'sub_status',
             'created_by',
+            'approved_by',
+            'location',
             'salesRep',
-            'driver'
+            'driver',
+            'returnReplacements.product',
         ])
             ->when($request->keyword, function ($query,$keyword) {
                 $query->where('so_number', 'LIKE', "%{$keyword}%")
@@ -362,7 +368,7 @@ class SalesOrderClass
         ];
     }
 
-    public function approve($id, $itemIds = []){
+    public function approve($id, $itemIds = [], $replacementItems = []){
         $data = SalesOrder::with('items')->findOrFail($id);
 
         $currentStatus = $data->status ? $data->status->slug : '';
@@ -421,13 +427,16 @@ class SalesOrderClass
                 );
             }
 
-            // Persist returned quantities so second returns can't re-return the same items
+            // Persist returned quantities so second returns can't re-return the same items.
+            // Capture effectiveQuantities BEFORE increment() mutates returned_quantity on the model.
+            $effectiveQuantities = [];
             foreach ($itemsToProcess as $item) {
                 $returnRequest = $returnRequests->get($item->id);
                 $returnQuantity = (int) ($returnRequest->return_quantity ?? $item->quantity);
                 $remainingReturnable = (int) $item->quantity - (int) $item->returned_quantity;
                 $effectiveQuantity = min($returnQuantity, $remainingReturnable);
                 if ($effectiveQuantity > 0) {
+                    $effectiveQuantities[$item->id] = $effectiveQuantity;
                     $item->increment('returned_quantity', $effectiveQuantity);
                 }
             }
@@ -447,89 +456,106 @@ class SalesOrderClass
                 $effectivePrice = max(0, (float) $item->price - (float) $item->discount_per_unit);
                 return min($returnQuantity, (int) $item->quantity) * $effectivePrice;
             });
+            $isCashSale = !in_array(strtolower((string) $data->payment_mode), ['credit', 'credit sales'], true);
             $refundReceipt = null;
             $updatedReceipt = null;
+            $extraReceipt = null;
 
             if ($isFullReturn) {
                 $data->update([
-                    'status_id' => ListStatus::getBySlug('sales-returned')?->id,
+                    'status_id'      => ListStatus::getBySlug('sales-returned')?->id,
                     'approved_by_id' => auth()->user()->id,
-                    'approved_at' => now(),
+                    'approved_at'    => now(),
                 ]);
 
-                $arInvoices = ArInvoice::where('sales_order_id', $id)->get();
-
-                foreach ($arInvoices as $invoice) {
-                    $receipts = Receipt::where('ar_invoice_id', $invoice->id)->get();
-
-                    foreach ($receipts as $receipt) {
-                        $this->journalEntryService->reverseEntriesForSource($receipt, 'Receipt voided because of full sales return.', now()->toDateString());
-                        $receipt->update([
-                            'status_id' => ListStatus::getBySlug('cancelled')?->id,
-                        ]);
+                if ($isCashSale) {
+                    // Cash: swap items — no refund, process replacements and charge any difference
+                    $extraReceipt = $this->processReplacementItems($data, $replacementItems, $refundAmount);
+                } else {
+                    // Credit: cancel all invoices and receipts, then add replacement to AR if any
+                    $arInvoices = ArInvoice::where('sales_order_id', $id)->get();
+                    foreach ($arInvoices as $invoice) {
+                        foreach (Receipt::where('ar_invoice_id', $invoice->id)->get() as $receipt) {
+                            $this->journalEntryService->reverseEntriesForSource($receipt, 'Receipt voided because of full sales return.', now()->toDateString());
+                            $receipt->update(['status_id' => ListStatus::getBySlug('cancelled')?->id]);
+                        }
+                        $invoice->update(['status_id' => ListStatus::getBySlug('cancelled')?->id]);
                     }
-
-                    $invoice->update([
-                        'status_id' => ListStatus::getBySlug('cancelled')?->id,
-                    ]);
+                    // Reset the first invoice's amounts so processReplacementItems only adds the extra charge.
+                    $firstInvoice = $arInvoices->first();
+                    if ($firstInvoice) {
+                        $firstInvoice->update(['amount_due' => 0, 'amount_paid' => 0, 'balance_due' => 0]);
+                    }
+                    if ($sourceReceipt) {
+                        $refundReceipt = $this->createRefundReceipt($data, $sourceReceipt, $refundAmount);
+                    }
+                    $extraReceipt = $this->processReplacementItems($data, $replacementItems, $refundAmount);
                 }
 
-                // Bug 12 fix: delete ALL sales_return_items for this order, not just the non-selected ones
+                $this->logReturnHistory($data, $itemsToProcess, $returnRequests, $effectiveQuantities);
+                if ($sourceReceipt) {
+                    $this->writeReturnNoteToReceipt($sourceReceipt, $itemsToProcess, $returnRequests, $replacementItems, $extraReceipt);
+                }
+
+                // Bug 12 fix: delete ALL sales_return_items for this order
                 DB::table('sales_return_items')
                     ->whereIn('sales_order_item_id', $data->items->pluck('id'))
                     ->delete();
 
-                if ($sourceReceipt) {
-                    $refundReceipt = $this->createRefundReceipt($data, $sourceReceipt, $refundAmount);
-                    // No updated receipt on full returns — the refund receipt is the complete paper trail
+                $this->journalEntryService->recordSalesReturnEntries($data, $itemsToProcess, $returnRequests, $sourceReceipt);
+                if (!empty($replacementItems)) {
+                    $this->journalEntryService->recordReplacementEntries($data, $replacementItems, $extraReceipt);
                 }
 
-                $this->journalEntryService->recordSalesReturnEntries($data, $itemsToProcess, $returnRequests, $sourceReceipt);
-
                 return [
-                    'data' => SalesOrder::find($id),
-                    'message' => 'Sales Order return approved successfully!',
-                    'info' => "You've successfully approved the full Sales Order return. The related receipts have been voided.",
-                    'receipt_id' => $refundReceipt?->id,
+                    'data'       => SalesOrder::find($id),
+                    'message'    => 'Sales Order return approved successfully!',
+                    'info'       => "Return approved. Replacement items have been issued.",
+                    'receipt_id' => $extraReceipt?->id ?? $refundReceipt?->id,
                 ];
             } else {
                 $data->update([
-                    'status_id' => ListStatus::getBySlug('partially-returned')?->id,
+                    'status_id'      => ListStatus::getBySlug('partially-returned')?->id,
                     'approved_by_id' => auth()->user()->id,
-                    'approved_at' => now(),
+                    'approved_at'    => now(),
                 ]);
 
-                $arInvoice = $data->arInvoices()->first();
-
-                // Fix: reduce amount_due to reflect returned items, then recompute balance
-                if ($arInvoice) {
-                    $newAmountDue = max(0, (float) $arInvoice->amount_due - $refundAmount);
-                    $arInvoice->amount_due = $newAmountDue;
-                    if ($sourceReceipt) {
-                        // Source receipt cancelled; customer gets refund but still owes for remaining items
+                if ($isCashSale) {
+                    // Cash: swap items — no refund, process replacements and charge any difference
+                    $extraReceipt = $this->processReplacementItems($data, $replacementItems, $refundAmount);
+                } else {
+                    // Credit: reduce AR balance by return value, then add replacement value back
+                    $arInvoice = $data->arInvoices()->first();
+                    if ($arInvoice) {
+                        $newAmountDue  = max(0, (float) $arInvoice->amount_due  - $refundAmount);
                         $newAmountPaid = max(0, (float) $arInvoice->amount_paid - $refundAmount);
+                        $arInvoice->amount_due  = $newAmountDue;
                         $arInvoice->amount_paid = $newAmountPaid;
                         $arInvoice->balance_due = max(0, $newAmountDue - $newAmountPaid);
-                    } else {
-                        // Credit sale with no receipt — reduce what the customer owes
-                        $arInvoice->balance_due = max(0, $newAmountDue - (float) $arInvoice->amount_paid);
+                        if ($arInvoice->balance_due <= 0) {
+                            $arInvoice->status_id = ListStatus::getBySlug('paid')?->id;
+                        } elseif ($newAmountPaid > 0) {
+                            $arInvoice->status_id = ListStatus::getBySlug('partially-paid')?->id;
+                        } else {
+                            $arInvoice->status_id = ListStatus::getBySlug('unpaid')?->id;
+                        }
+                        $arInvoice->save();
                     }
-
-                    if ($arInvoice->balance_due <= 0) {
-                        $arInvoice->status_id = ListStatus::getBySlug('paid')?->id;
-                    } elseif ($arInvoice->amount_paid > 0) {
-                        $arInvoice->status_id = ListStatus::getBySlug('partially-paid')?->id;
-                    } else {
-                        $arInvoice->status_id = ListStatus::getBySlug('unpaid')?->id;
+                    if ($sourceReceipt) {
+                        $sourceReceipt->load('status');
+                        $originalStatusSlug = $sourceReceipt->status?->slug ?? 'pending';
+                        $this->journalEntryService->reverseEntriesForSource($sourceReceipt, 'Receipt voided because of partial sales return.', now()->toDateString());
+                        $sourceReceipt->update(['status_id' => ListStatus::getBySlug('cancelled')?->id]);
+                        $refundReceipt  = $this->createRefundReceipt($data, $sourceReceipt, $refundAmount);
+                        $updatedReceipt = $this->createUpdatedReceipt($data, $refundReceipt, $originalStatusSlug);
                     }
-                    $arInvoice->save();
+                    // Add replacement items to AR invoice (customer owes the replacement value)
+                    $extraReceipt = $this->processReplacementItems($data, $replacementItems, $refundAmount);
                 }
 
+                $this->logReturnHistory($data, $itemsToProcess, $returnRequests, $effectiveQuantities);
                 if ($sourceReceipt) {
-                    $this->journalEntryService->reverseEntriesForSource($sourceReceipt, 'Receipt voided because of partial sales return.', now()->toDateString());
-                    $sourceReceipt->update([
-                        'status_id' => ListStatus::getBySlug('cancelled')?->id,
-                    ]);
+                    $this->writeReturnNoteToReceipt($sourceReceipt, $itemsToProcess, $returnRequests, $replacementItems, $extraReceipt);
                 }
 
                 // Bug 13 fix: delete ALL sales_return_items for this order after partial return approval
@@ -537,21 +563,19 @@ class SalesOrderClass
                     ->whereIn('sales_order_item_id', $data->items->pluck('id'))
                     ->delete();
 
-                if ($sourceReceipt) {
-                    $refundReceipt = $this->createRefundReceipt($data, $sourceReceipt, $refundAmount);
-                    $updatedReceipt = $this->createUpdatedReceipt($data, $refundReceipt);
-                }
-
                 $this->journalEntryService->recordSalesReturnEntries($data, $itemsToProcess, $returnRequests, $sourceReceipt);
                 if ($updatedReceipt) {
                     $this->journalEntryService->recordReceiptEntry($updatedReceipt);
                 }
+                if (!empty($replacementItems)) {
+                    $this->journalEntryService->recordReplacementEntries($data, $replacementItems, $extraReceipt);
+                }
 
                 return [
-                    'data' => SalesOrder::find($id),
-                    'message' => 'Partial Sales Order return approved successfully!',
-                    'info' => "You've successfully approved the partial Sales Order return. The inventory has been restored for returned items and the invoice has been adjusted.",
-                    'receipt_id' => $updatedReceipt?->id,
+                    'data'       => SalesOrder::find($id),
+                    'message'    => 'Partial Sales Order return approved successfully!',
+                    'info'       => "Return approved. Replacement items have been issued.",
+                    'receipt_id' => $extraReceipt?->id ?? $updatedReceipt?->id,
                 ];
             }
         } else {
@@ -876,7 +900,193 @@ class SalesOrderClass
         ]);
     }
 
-    private function createUpdatedReceipt(SalesOrder $salesOrder, ?Receipt $refundReceipt): ?Receipt
+    private function processReplacementItems(SalesOrder $salesOrder, array $replacementItems, float $returnValue): ?Receipt
+    {
+        if (empty($replacementItems)) {
+            return null;
+        }
+
+        $replacementTotal = 0;
+        foreach ($replacementItems as $item) {
+            $productId = (int) ($item['product_id'] ?? 0);
+            $quantity  = (int) ($item['quantity']   ?? 0);
+            $price     = (float) ($item['price']    ?? 0);
+            if ($productId <= 0 || $quantity <= 0) {
+                continue;
+            }
+            $replacementTotal += $quantity * $price;
+        }
+
+        if (round($replacementTotal, 2) < round($returnValue, 2)) {
+            throw ValidationException::withMessages([
+                'replacement' => 'Replacement value (' . number_format($replacementTotal, 2) . ') must be equal to or greater than the return value (' . number_format($returnValue, 2) . '). No under-value replacements are allowed.',
+            ]);
+        }
+
+        foreach ($replacementItems as $item) {
+            $productId = (int) ($item['product_id'] ?? 0);
+            $quantity  = (int) ($item['quantity']   ?? 0);
+            $price     = (float) ($item['price']    ?? 0);
+            if ($productId <= 0 || $quantity <= 0) continue;
+            $this->inventoryService->deductStock(
+                $productId,
+                $quantity,
+                'Sales Return Replacement - SO#' . $salesOrder->so_number,
+            );
+            \App\Models\SalesReturnReplacement::create([
+                'sales_order_id' => $salesOrder->id,
+                'product_id'     => $productId,
+                'quantity'       => $quantity,
+                'price'          => $price,
+                'total_value'    => $quantity * $price,
+                'replaced_at'    => now()->toDateString(),
+                'replaced_by_id' => auth()->id(),
+            ]);
+        }
+
+        $extraAmount = max(0, round($replacementTotal - $returnValue, 2));
+        if ($extraAmount <= 0) {
+            return null;
+        }
+
+        $arInvoice = $salesOrder->arInvoices()->first();
+        if (!$arInvoice) {
+            return null;
+        }
+
+        $arInvoice->amount_due  = (float) $arInvoice->amount_due  + $extraAmount;
+        $arInvoice->balance_due = (float) $arInvoice->balance_due + $extraAmount;
+        $arInvoice->status_id   = ListStatus::getBySlug('partially-paid')?->id;
+        $arInvoice->save();
+
+        return Receipt::create([
+            'ar_invoice_id'  => $arInvoice->id,
+            'customer_id'    => $salesOrder->customer_id,
+            'status_id'      => ListStatus::getBySlug('pending')?->id,
+            'receipt_number' => Receipt::generateReceiptNumber(),
+            'receipt_type'   => 'payment',
+            'receipt_date'   => now()->toDateString(),
+            'amount_paid'    => $extraAmount,
+            'balance_due'    => $extraAmount,
+            'payment_mode'   => $salesOrder->payment_mode,
+        ]);
+    }
+
+    private function writeReturnNoteToReceipt(Receipt $receipt, $itemsToProcess, $returnRequests, array $replacementItems, ?Receipt $extraReceipt = null): void
+    {
+        $returnedLines = [];
+        foreach ($itemsToProcess as $item) {
+            $returnRequest  = $returnRequests->get($item->id);
+            $returnQuantity = (int) ($returnRequest->return_quantity ?? $item->quantity);
+            $product        = Product::find($item->product_id);
+            $productName    = $product?->name ?? "Product #{$item->product_id}";
+            $returnedLines[] = "{$productName} ×{$returnQuantity}";
+        }
+
+        $replacementLines = [];
+        $replacementTotal = 0;
+        foreach ($replacementItems as $rep) {
+            $productId  = (int) ($rep['product_id'] ?? 0);
+            $quantity   = (int) ($rep['quantity']   ?? 0);
+            $price      = (float) ($rep['price']    ?? 0);
+            if ($productId <= 0 || $quantity <= 0) continue;
+            $product    = Product::find($productId);
+            $name       = $product?->name ?? "Product #{$productId}";
+            $replacementLines[] = "{$name} ×{$quantity}";
+            $replacementTotal += $quantity * $price;
+        }
+
+        $date     = now()->format('Y-m-d H:i');
+        $returned = implode(', ', $returnedLines);
+        $newNote  = "[{$date}] Return adjustment — Returned: {$returned}.";
+
+        if (!empty($replacementLines)) {
+            $replaced = implode(', ', $replacementLines);
+            $newNote .= " Replaced with: {$replaced}.";
+        }
+
+        if ($extraReceipt) {
+            $extra = number_format((float) $extraReceipt->amount_paid, 2);
+            $newNote .= " Extra charged: ₱{$extra} (Receipt #{$extraReceipt->receipt_number}).";
+
+            $extraNote = "[{$date}] Additional charge — replacement exceeded return value by ₱{$extra}. Ref: original receipt #{$receipt->receipt_number}.";
+            $extraReceipt->update(['notes' => $extraNote]);
+        }
+
+        $existing = $receipt->notes ? $receipt->notes . "\n" : '';
+        $receipt->update(['notes' => $existing . $newNote]);
+    }
+
+    private function logReturnHistory(SalesOrder $salesOrder, $itemsToProcess, $returnRequests, array $effectiveQuantities = []): void
+    {
+        foreach ($itemsToProcess as $item) {
+            // Use pre-computed quantity to avoid stale post-increment value on the model.
+            $effectiveQuantity = $effectiveQuantities[$item->id] ?? 0;
+            if ($effectiveQuantity <= 0) {
+                continue;
+            }
+            $returnRequest = $returnRequests->get($item->id);
+            $unitPrice = max(0, (float) $item->price - (float) $item->discount_per_unit);
+            SalesReturnHistory::create([
+                'sales_order_id'      => $salesOrder->id,
+                'sales_order_item_id' => $item->id,
+                'product_id'          => $item->product_id,
+                'quantity'            => $effectiveQuantity,
+                'condition'           => (string) ($returnRequest->return_condition ?? 'restockable'),
+                'unit_price'          => $unitPrice,
+                'total_value'         => $effectiveQuantity * $unitPrice,
+                'returned_at'         => now()->toDateString(),
+                'approved_by_id'      => auth()->id(),
+            ]);
+        }
+    }
+
+    public function returnHistory($request): array
+    {
+        $from = $request->from ? Carbon::parse($request->from)->startOfDay() : Carbon::now()->startOfMonth()->startOfDay();
+        $to   = $request->to   ? Carbon::parse($request->to)->endOfDay()   : Carbon::now()->endOfMonth()->endOfDay();
+
+        $rows = SalesReturnHistory::with(['product', 'salesOrder.customer', 'approvedBy'])
+            ->whereBetween('returned_at', [$from->toDateString(), $to->toDateString()])
+            ->when($request->condition, fn($q, $c) => $q->where('condition', $c))
+            ->orderByDesc('returned_at')
+            ->get();
+
+        $summary = [
+            'restockable' => ['qty' => 0, 'value' => 0],
+            'damaged'     => ['qty' => 0, 'value' => 0],
+            'loss'        => ['qty' => 0, 'value' => 0],
+        ];
+
+        foreach ($rows as $row) {
+            $cond = $row->condition;
+            if (!isset($summary[$cond])) {
+                $summary[$cond] = ['qty' => 0, 'value' => 0];
+            }
+            $summary[$cond]['qty']   += $row->quantity;
+            $summary[$cond]['value'] += (float) $row->total_value;
+        }
+
+        return [
+            'rows'    => $rows->map(fn($r) => [
+                'id'           => $r->id,
+                'so_number'    => $r->salesOrder?->so_number,
+                'customer'     => $r->salesOrder?->customer?->name,
+                'product'      => $r->product?->name,
+                'quantity'     => $r->quantity,
+                'condition'    => $r->condition,
+                'unit_price'   => $r->unit_price,
+                'total_value'  => $r->total_value,
+                'returned_at'  => $r->returned_at?->format('Y-m-d'),
+                'approved_by'  => $r->approvedBy?->name,
+            ]),
+            'summary' => $summary,
+            'from'    => $from->toDateString(),
+            'to'      => $to->toDateString(),
+        ];
+    }
+
+    private function createUpdatedReceipt(SalesOrder $salesOrder, ?Receipt $refundReceipt, string $originalStatusSlug = 'pending'): ?Receipt
     {
         if (!$refundReceipt) {
             return null;
@@ -895,10 +1105,14 @@ class SalesOrderClass
 
         $adjustedAmountPaid = max(0, (float) ($originalReceipt->amount_paid - $refundReceipt->amount_paid));
 
+        // Inherit the original receipt's status — if it was already liquidated/remitted,
+        // the adjusted receipt needs no remittance either.
+        $inheritedStatus = in_array($originalStatusSlug, ['liquidated', 'paid']) ? 'liquidated' : 'pending';
+
         return Receipt::create([
             'ar_invoice_id' => $invoice->id,
             'customer_id' => $salesOrder->customer_id,
-            'status_id' => ListStatus::getBySlug('paid')?->id,
+            'status_id' => ListStatus::getBySlug($inheritedStatus)?->id,
             'receipt_number' => Receipt::generateReceiptNumber(),
             'receipt_type' => 'updated',
             'source_receipt_id' => $refundReceipt->id,

--- a/database/migrations/2026_06_25_000003_create_sales_return_history_table.php
+++ b/database/migrations/2026_06_25_000003_create_sales_return_history_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sales_return_history', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('sales_order_id');
+            $table->unsignedInteger('sales_order_item_id');
+            $table->unsignedInteger('product_id');
+            $table->integer('quantity');
+            $table->string('condition');
+            $table->decimal('unit_price', 15, 2)->default(0);
+            $table->decimal('total_value', 15, 2)->default(0);
+            $table->date('returned_at');
+            $table->unsignedInteger('approved_by_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('sales_order_id')->references('id')->on('sales_orders')->onDelete('cascade');
+            $table->foreign('approved_by_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_return_history');
+    }
+};

--- a/database/migrations/2026_06_30_000001_create_app_settings_table.php
+++ b/database/migrations/2026_06_30_000001_create_app_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('app_settings', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+
+        DB::table('app_settings')->insert([
+            ['key' => 'return_grace_period', 'value' => '7', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('app_settings');
+    }
+};

--- a/database/migrations/2026_06_30_000002_add_notes_to_receipts_table.php
+++ b/database/migrations/2026_06_30_000002_add_notes_to_receipts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('receipts', function (Blueprint $table) {
+            $table->text('notes')->nullable()->after('payment_mode');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('receipts', function (Blueprint $table) {
+            $table->dropColumn('notes');
+        });
+    }
+};

--- a/database/migrations/2026_06_30_000003_create_sales_return_replacements_table.php
+++ b/database/migrations/2026_06_30_000003_create_sales_return_replacements_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sales_return_replacements', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->unsignedInteger('sales_order_id');
+            $table->unsignedInteger('product_id');
+            $table->integer('quantity');
+            $table->decimal('price', 15, 2)->default(0);
+            $table->decimal('total_value', 15, 2)->default(0);
+            $table->date('replaced_at');
+            $table->unsignedInteger('replaced_by_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('sales_order_id')->references('id')->on('sales_orders')->onDelete('cascade');
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade');
+            $table->foreign('replaced_by_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales_return_replacements');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         $this->call(CustomersTableSeeder::class);
         $this->call(ListBrandsTableSeeder::class);
         $this->call(ListUnitsTableSeeder::class);
+        $this->call(ListPackagingsTableSeeder::class);
         $this->call(ProductsTableSeeder::class);
         $this->call(ListSuppliersTableSeeder::class);
         $this->call(ListLocationsTableSeeder::class);

--- a/resources/js/Pages/Modules/Sales/Components/Remittances/Details/RemittanceDetails.vue
+++ b/resources/js/Pages/Modules/Sales/Components/Remittances/Details/RemittanceDetails.vue
@@ -5,12 +5,8 @@
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h6 class="text-primary mb-0">#{{ item.remittance_no }}</h6>
                     <div>
-                        <button @click.stop="openApprovalModal()" class="action-btn approve me-1" v-if="['open', 'remitted'].includes(item.status?.slug)" title="Approve">
+                        <button @click.stop="openApprovalModal()" class="action-btn approve me-1" v-if="item.status?.slug === 'open'" title="Approve">
                             <i class="ri-check-line"></i>
-                        </button>
-                        <button @click.stop="markAsRemitted()" class="action-btn info me-1" v-if="item.status?.slug == 'open'" :disabled="isRemitting" title="Mark as Remitted">
-                            <i v-if="isRemitting" class="ri-loader-4-line"></i>
-                            <i v-else class="ri-send-plane-line"></i>
                         </button>
                         <button @click.stop="onPrint(item.id)" class="action-btn info me-1" title="Print">
                             <i class="ri-printer-line"></i>

--- a/resources/js/Pages/Modules/Sales/Components/Remittances/Index.vue
+++ b/resources/js/Pages/Modules/Sales/Components/Remittances/Index.vue
@@ -71,11 +71,6 @@
                                         <span>Open</span>
                                         <span v-if="activeTab === 'open'" class="seg-count">{{ meta.total ?? 0 }}</span>
                                     </button>
-                                    <button :class="['filter-segment-btn', activeTab === 'remitted' ? 'active' : '']" @click="switchTab('remitted')">
-                                        <i class="ri-send-plane-line"></i>
-                                        <span>Remitted</span>
-                                        <span v-if="activeTab === 'remitted'" class="seg-count">{{ meta.total ?? 0 }}</span>
-                                    </button>
                                     <button :class="['filter-segment-btn', activeTab === 'liquidated' ? 'active' : '']" @click="switchTab('liquidated')">
                                         <i class="ri-checkbox-circle-line"></i>
                                         <span>Liquidated</span>
@@ -136,47 +131,6 @@
                                     </table>
                                 </div>
 
-                                <div v-show="activeTab === 'remitted'" class="table-responsive">
-                                    <table class="table sales-table mb-0">
-                                        <thead>
-                                            <tr>
-                                                <th style="width:3%">#</th>
-                                                <th class="text-center" style="width:15%">Remittance No.</th>
-                                                <th class="text-center" style="width:15%">Date</th>
-                                                <th class="text-end" style="width:15%">Amount</th>
-                                                <th class="text-center" style="width:20%">Sales Rep</th>
-                                                <th class="text-center" style="width:7%">Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr v-if="remittedRemittance.length === 0">
-                                                <td colspan="6">
-                                                    <div class="sales-empty-state">
-                                                        <i class="ri-inbox-line"></i>
-                                                        <p>No remitted remittances found.</p>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                            <tr
-                                                v-for="(item, index) in remittedRemittance"
-                                                :key="item.id || index"
-                                                class="cursor-pointer"
-                                                @click="openView(item)"
-                                            >
-                                                <td>{{ index + 1 }}</td>
-                                                <td class="text-center fw-semibold">{{ item.remittance_no || '-' }}</td>
-                                                <td class="text-center">{{ item.date || item.remittance_date }}</td>
-                                                <td class="text-end">{{ formatCurrency(item.total_amount) }}</td>
-                                                <td class="text-center">{{ item.created_by?.fullname || '-' }}</td>
-                                                <td class="text-center">
-                                                    <button @click.stop="openView(item)" class="action-btn info" title="View">
-                                                        <i class="ri-eye-line"></i>
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
 
                                 <div v-show="activeTab === 'liquidated'" class="table-responsive">
                                     <table class="table sales-table mb-0">
@@ -324,7 +278,6 @@ export default {
     },
     computed: {
         openRemittance() { return this.lists; },
-        remittedRemittance() { return this.lists; },
         liquidatedRemittance() { return this.lists; },
         disapprovedRemittance() { return this.lists; },
         isSalesRep() {

--- a/resources/js/Pages/Modules/Sales/Components/Remittances/Modals/Create.vue
+++ b/resources/js/Pages/Modules/Sales/Components/Remittances/Modals/Create.vue
@@ -69,25 +69,19 @@
                     <div>
                         <h6 class="text-primary"><i class="ri-money-dollar-circle-line"></i> Summary</h6>
                         <div class="row g-2">
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <div class="p-2 bg-light rounded">
-                                    <small class="text-muted">Cash</small>
-                                    <div class="fw-bold">{{ formatAmount(totals.cash) }}</div>
+                                    <small class="text-muted">Cash Sales</small>
+                                    <div class="fw-bold">{{ formatAmount(totals.cash_sales) }}</div>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <div class="p-2 bg-light rounded">
-                                    <small class="text-muted">Credit Card</small>
-                                    <div class="fw-bold">{{ formatAmount(totals.credit_card) }}</div>
+                                    <small class="text-muted">Credit Sales</small>
+                                    <div class="fw-bold">{{ formatAmount(totals.credit_sales) }}</div>
                                 </div>
                             </div>
-                            <div class="col-md-3">
-                                <div class="p-2 bg-light rounded">
-                                    <small class="text-muted">Debit Card</small>
-                                    <div class="fw-bold">{{ formatAmount(totals.debit_card) }}</div>
-                                </div>
-                            </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <div class="p-2 bg-light rounded">
                                     <small class="text-muted">Bank Transfer</small>
                                     <div class="fw-bold">{{ formatAmount(totals.bank_transfer) }}</div>
@@ -159,15 +153,14 @@ export default {
             return Math.max(1, Math.ceil(this.filteredOrders.length / this.pageSize));
         },
         totals() {
-            const t = { cash: 0, credit_card: 0, debit_card: 0, bank_transfer: 0, overall: 0 };
+            const t = { cash_sales: 0, credit_sales: 0, bank_transfer: 0, overall: 0 };
             const selected = this.orders.filter(o => this.selectedIds.includes(o.id));
             selected.forEach(o => {
                 const amt = parseFloat(o.amount_paid) || 0;
                 const mode = this.normalizeSalesPaymentMode(o);
-                if (mode === 'cash') t.cash += amt;
-                else if (mode === 'credit card' || mode === 'credit_card' || mode === 'creditcard') t.credit_card += amt;
-                else if (mode === 'debit card' || mode === 'debit_card' || mode === 'debitcard') t.debit_card += amt;
-                else if (mode === 'bank transfer' || mode === 'bank_transfer' || mode === 'banktransfer') t.bank_transfer += amt;
+                if (mode === 'credit' || mode === 'credit sales') t.credit_sales += amt;
+                else if (mode === 'bank transfer' || mode === 'bank_transfer') t.bank_transfer += amt;
+                else t.cash_sales += amt;
                 t.overall += amt;
             });
             return t;
@@ -227,7 +220,9 @@ export default {
             return order?.customer?.name || order?.ar_invoice?.sales_order?.customer?.name || '-';
         },
         getPaymentMode(order) {
-            return order?.payment_mode || order?.ar_invoice?.sales_order?.payment_mode || '';
+            const raw = String(order?.payment_mode || order?.ar_invoice?.sales_order?.payment_mode || '').trim().toLowerCase();
+            if (raw === 'credit' || raw === 'credit sales') return 'Credit Sales';
+            return 'Cash Sales';
         },
         normalizeSalesPaymentMode(order) {
             return String(this.getPaymentMode(order) || '').trim().toLowerCase();

--- a/resources/js/Pages/Modules/Sales/Components/Remittances/View.vue
+++ b/resources/js/Pages/Modules/Sales/Components/Remittances/View.vue
@@ -13,14 +13,9 @@
                     </div>
 
                     <div class="d-flex gap-2 flex-wrap">
-                        <button v-if="canApprove && ['open', 'remitted'].includes(item.status?.slug)" class="create-btn" @click="openApprovalModal">
+                        <button v-if="canApprove && item.status?.slug === 'open'" class="create-btn" @click="openApprovalModal">
                             <i class="ri-check-line"></i>
                             <span>Approval</span>
-                        </button>
-                        <button v-if="item.status?.slug === 'open'" class="create-btn" @click="markAsRemitted" :disabled="isRemitting">
-                            <i v-if="isRemitting" class="ri-loader-4-line"></i>
-                            <i v-else class="ri-send-plane-line"></i>
-                            <span>{{ isRemitting ? 'Submitting...' : 'Mark as Remitted' }}</span>
                         </button>
                         <button v-if="item.status?.slug === 'open'" class="create-btn" @click="openDelete(item.id)">
                             <i class="ri-delete-bin-line"></i>
@@ -316,7 +311,6 @@ export default {
             if (['approved', 'completed', 'liquidated'].includes(value)) return 'emp-status-success';
             if (['rejected', 'disapproved', 'cancelled'].includes(value)) return 'emp-status-danger';
             if (['open', 'pending'].includes(value)) return 'emp-status-warning';
-            if (value === 'remitted') return 'emp-status-info';
 
             return 'profile-badge-neutral';
         },

--- a/resources/js/Pages/Modules/Sales/Components/SalesReturns/Index.vue
+++ b/resources/js/Pages/Modules/Sales/Components/SalesReturns/Index.vue
@@ -1,6 +1,18 @@
 <template>
     <div>
-        <div class="col-lg-12 mb-4">
+        <!-- Sub-tab switcher -->
+        <div class="d-flex gap-2 mb-3">
+            <button class="sub-tab-btn" :class="{ active: activeSubTab === 'list' }" @click="activeSubTab = 'list'">
+                <i class="ri-list-check me-1"></i> Returns List
+            </button>
+            <button class="sub-tab-btn" :class="{ active: activeSubTab === 'history' }" @click="activeSubTab = 'history'">
+                <i class="ri-history-line me-1"></i> Returns History
+            </button>
+        </div>
+
+        <ReturnHistory v-if="activeSubTab === 'history'" :isExternal="isExternal" />
+
+        <div v-if="activeSubTab === 'list'" class="col-lg-12 mb-4">
             <div class="library-card">
                 <div class="library-card-header">
                         <div class="d-flex align-items-center gap-3">
@@ -12,10 +24,15 @@
                                 <p class="header-subtitle mb-0">A comprehensive list of Returned Sales Orders</p>
                             </div>
                         </div>
-                        <button class="acct-btn-primary" @click="openCreate">
-                            <i class="ri-add-line"></i>
-                            <span>Sales Return</span>
-                        </button>
+                        <div class="d-flex align-items-center gap-2">
+                            <button v-if="isAdmin" class="btn btn-sm btn-outline-secondary" @click="openSettings" title="Return Settings">
+                                <i class="ri-settings-3-line"></i>
+                            </button>
+                            <button class="acct-btn-primary" @click="openCreate">
+                                <i class="ri-add-line"></i>
+                                <span>Sales Return</span>
+                            </button>
+                        </div>
 
                 </div>
                 <div class="library-card-body">
@@ -124,51 +141,156 @@
                                         <td colspan="12" class="p-0">
                                             <div class="details-container">
                                                 <div class="details-content">
-                                                    <div class="row g-4">
-                                                        <div class="col-md-6">
-                                                            <div class="info-card order-card">
-                                                                <div class="info-card-header">
-                                                                    <i class="ri-file-list-line"></i>
-                                                                    <h6>Order Information</h6>
+                                                    <div class="row g-3">
+
+                                                        <!-- Order Info -->
+                                                        <div class="col-md-4">
+                                                            <div class="det-card">
+                                                                <div class="det-card-header">
+                                                                    <i class="ri-file-list-3-line"></i>
+                                                                    <span>Order Info</span>
                                                                 </div>
-                                                                <div class="info-card-body">
-                                                                    <div class="info-item">
-                                                                        <span class="info-label">Order Date:</span>
-                                                                        <span class="info-value">{{ list.order_date }}</span>
+                                                                <div class="det-card-body">
+                                                                    <div class="det-row">
+                                                                        <span class="det-label">Order Date</span>
+                                                                        <span class="det-value">{{ list.order_date }}</span>
                                                                     </div>
-                                                                    <div class="info-item">
-                                                                        <span class="info-label">Added By:</span>
-                                                                        <span class="info-value">{{ list.added_by?.name || '-' }}</span>
+                                                                    <div class="det-row">
+                                                                        <span class="det-label">Payment Mode</span>
+                                                                        <span class="det-value">
+                                                                            <span class="mode-pill" :class="list.payment_mode?.toLowerCase().includes('credit') ? 'mode-credit' : 'mode-cash'">
+                                                                                {{ list.payment_mode || '-' }}
+                                                                            </span>
+                                                                        </span>
                                                                     </div>
-                                                                    <div class="info-item">
-                                                                        <span class="info-label">Transferred To:</span>
-                                                                        <span class="info-value">{{ list.transferred_to || '-' }}</span>
+                                                                    <div class="det-row" v-if="list.due_date">
+                                                                        <span class="det-label">Due Date</span>
+                                                                        <span class="det-value">{{ list.due_date }}</span>
+                                                                    </div>
+                                                                    <div class="det-row">
+                                                                        <span class="det-label">Location</span>
+                                                                        <span class="det-value">{{ list.location?.name || '-' }}</span>
+                                                                    </div>
+                                                                    <div class="det-row">
+                                                                        <span class="det-label">Added By</span>
+                                                                        <span class="det-value">{{ list.added_by?.name || '-' }}</span>
+                                                                    </div>
+                                                                    <div class="det-row">
+                                                                        <span class="det-label">Approved By</span>
+                                                                        <span class="det-value">{{ list.approved_by_user || '-' }}</span>
+                                                                    </div>
+                                                                    <div class="det-row" v-if="list.approved_at">
+                                                                        <span class="det-label">Approved At</span>
+                                                                        <span class="det-value">{{ list.approved_at }}</span>
                                                                     </div>
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                        <div class="col-md-6">
-                                                            <div class="info-card items-card">
-                                                                <div class="info-card-header">
-                                                                    <i class="ri-shopping-bag-line"></i>
-                                                                    <h6>Items</h6>
+
+                                                        <!-- Payment / Invoice -->
+                                                        <div class="col-md-4">
+                                                            <div class="det-card">
+                                                                <div class="det-card-header">
+                                                                    <i class="ri-bill-line"></i>
+                                                                    <span>Payment & Invoice</span>
                                                                 </div>
-                                                                <div class="info-card-body">
-                                                                    <div v-if="list.items && list.items.length > 0">
-                                                                        <div v-for="item in list.items" :key="item.id" class="info-item">
-                                                                            <span class="info-label">
-                                                                                {{ getProduct(item.product_id).name || 'Unknown Product' }}
-                                                                            </span>
-                                                                            <span class="info-value">
-                                                                                <span class="badge bg-primary">{{ item.quantity }} {{ item.unit }}</span>
-                                                                                <span class="badge bg-secondary ms-1">₱{{ item.price }}</span>
-                                                                            </span>
-                                                                        </div>
-                                                                    </div>
-                                                                    <p v-else class="text-muted mb-0">No items found</p>
+                                                                <div class="det-card-body">
+                                                                    <template v-if="list.invoices && list.invoices.length > 0">
+                                                                        <template v-for="inv in list.invoices" :key="inv.id">
+                                                                            <div class="det-row">
+                                                                                <span class="det-label">Invoice #</span>
+                                                                                <span class="det-value fw-semibold">{{ inv.invoice_number }}</span>
+                                                                            </div>
+                                                                            <div class="det-row">
+                                                                                <span class="det-label">Amount Due</span>
+                                                                                <span class="det-value">{{ formatCurrency(inv.amount_due) }}</span>
+                                                                            </div>
+                                                                            <div class="det-row">
+                                                                                <span class="det-label">Amount Paid</span>
+                                                                                <span class="det-value text-success">{{ formatCurrency(inv.amount_paid) }}</span>
+                                                                            </div>
+                                                                            <div class="det-row">
+                                                                                <span class="det-label">Balance</span>
+                                                                                <span class="det-value" :class="inv.balance_due > 0 ? 'text-danger' : 'text-success'">{{ formatCurrency(inv.balance_due) }}</span>
+                                                                            </div>
+                                                                            <div class="det-divider" v-if="inv.receipts && inv.receipts.length > 0"></div>
+                                                                            <div v-for="r in inv.receipts" :key="r.id" class="det-row det-receipt-row">
+                                                                                <span class="det-label">{{ r.receipt_number }}</span>
+                                                                                <span class="det-value d-flex align-items-center gap-1">
+                                                                                    <span class="small text-muted">{{ formatCurrency(r.amount_paid) }}</span>
+                                                                                    <span class="rcpt-badge" :style="{ background: r.status?.bg_color + '22', color: r.status?.text_color }">{{ r.status?.name }}</span>
+                                                                                </span>
+                                                                            </div>
+                                                                        </template>
+                                                                    </template>
+                                                                    <p v-else class="text-muted small mb-0">No invoice found</p>
                                                                 </div>
                                                             </div>
                                                         </div>
+
+                                                        <!-- Items & Replacements -->
+                                                        <div class="col-md-4">
+                                                            <div class="det-card mb-3">
+                                                                <div class="det-card-header">
+                                                                    <i class="ri-shopping-bag-3-line"></i>
+                                                                    <span>Items</span>
+                                                                </div>
+                                                                <div class="det-card-body p-0">
+                                                                    <table class="det-items-table" v-if="list.items && list.items.length > 0">
+                                                                        <thead>
+                                                                            <tr>
+                                                                                <th>Product</th>
+                                                                                <th class="text-center">Sold</th>
+                                                                                <th class="text-center">Returned</th>
+                                                                                <th class="text-end">Price</th>
+                                                                            </tr>
+                                                                        </thead>
+                                                                        <tbody>
+                                                                            <tr v-for="item in list.items" :key="item.id">
+                                                                                <td>
+                                                                                    <div class="fw-semibold" style="font-size:12px">{{ item.product_name || getProduct(item.product_id).name }}</div>
+                                                                                    <div class="text-muted" style="font-size:11px">{{ item.batch_code || '-' }}</div>
+                                                                                </td>
+                                                                                <td class="text-center" style="font-size:12px">{{ item.quantity }}</td>
+                                                                                <td class="text-center">
+                                                                                    <span v-if="item.returned_quantity > 0" class="ret-badge">{{ item.returned_quantity }}</span>
+                                                                                    <span v-else class="text-muted" style="font-size:11px">—</span>
+                                                                                </td>
+                                                                                <td class="text-end" style="font-size:12px">{{ formatCurrency(item.price) }}</td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </table>
+                                                                    <p v-else class="text-muted small mb-0 p-3">No items found</p>
+                                                                </div>
+                                                            </div>
+
+                                                            <!-- Replacement Items -->
+                                                            <div class="det-card" v-if="list.return_replacements && list.return_replacements.length > 0">
+                                                                <div class="det-card-header" style="background:linear-gradient(to right,#fff8e1,#fffdf0);border-bottom-color:#ffe082;">
+                                                                    <i class="ri-exchange-line" style="color:#f59e0b;"></i>
+                                                                    <span style="color:#92610a;">Replacement Items</span>
+                                                                </div>
+                                                                <div class="det-card-body p-0">
+                                                                    <table class="det-items-table">
+                                                                        <thead>
+                                                                            <tr>
+                                                                                <th>Product</th>
+                                                                                <th class="text-center">Qty</th>
+                                                                                <th class="text-end">Total</th>
+                                                                            </tr>
+                                                                        </thead>
+                                                                        <tbody>
+                                                                            <tr v-for="rep in list.return_replacements" :key="rep.id">
+                                                                                <td class="fw-semibold" style="font-size:12px">{{ rep.product_name }}</td>
+                                                                                <td class="text-center" style="font-size:12px">{{ rep.quantity }}</td>
+                                                                                <td class="text-end" style="font-size:12px">{{ formatCurrency(rep.total_value) }}</td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </table>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+
                                                     </div>
                                                 </div>
                                             </div>
@@ -194,13 +316,42 @@
                 </div>
             </div>
         </div>
-    </div>
-    <CreateFromReceipt @add="fetch()" :dropdowns="dropdowns" ref="create"/>
-    <Cancel @cancel="fetch()" ref="cancel"/>
-<Approval @approve="fetch()" ref="approval" :products="dropdowns.products"/>
-    <Adjustment @update="fetch()"  ref="adjustment"/>
 
-    
+        <CreateFromReceipt @add="fetch()" :dropdowns="dropdowns" :returnGracePeriod="gracePeriod" ref="create"/>
+        <Cancel @cancel="fetch()" ref="cancel"/>
+        <Approval @approve="fetch()" ref="approval" :products="dropdowns.products"/>
+        <Adjustment @update="fetch()" ref="adjustment"/>
+
+        <!-- Return Settings Modal -->
+        <div v-if="showSettings" class="modal-overlay active" @click.self="showSettings = false">
+            <div class="modal-container settings-modal" @click.stop>
+                <div class="modal-header">
+                    <div>
+                        <h2 class="mb-1">Return Settings</h2>
+                        <p class="mb-0 header-subtitle">Configure the sales return grace period.</p>
+                    </div>
+                    <button type="button" class="close-btn" @click="showSettings = false">
+                        <i class="ri-close-line"></i>
+                    </button>
+                </div>
+                <div class="modal-body p-4">
+                    <div class="settings-field">
+                        <label class="form-label fw-semibold mb-1">Return Grace Period (days)</label>
+                        <p class="text-muted small mb-2">Customers can only return items within this many days from their purchase date.</p>
+                        <input type="number" v-model.number="settingsForm.gracePeriod" min="1" max="365" class="form-control" style="max-width:160px">
+                    </div>
+                </div>
+                <div class="modal-footer d-flex justify-content-end gap-2">
+                    <button class="btn btn-secondary" @click="showSettings = false">Cancel</button>
+                    <button class="btn btn-primary" @click="saveSettings" :disabled="settingsSaving">
+                        <i class="ri-loader-4-line spinner me-1" v-if="settingsSaving"></i>
+                        <i class="ri-save-line me-1" v-else></i>
+                        {{ settingsSaving ? 'Saving...' : 'Save' }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
 </template>
 <script>
 import _ from 'lodash';
@@ -211,13 +362,19 @@ import Cancel from './Modals/Cancel.vue';
 import CreateFromReceipt from './Modals/CreateFromReceipt.vue';
 import Adjustment from './Modals/Adjustment.vue';
 import Approval from './Modals/Approval.vue';
+import ReturnHistory from './ReturnHistory.vue';
 
 
 export default {
-    components: { PageHeader, Pagination, Multiselect , CreateFromReceipt, Cancel, Adjustment, Approval },
-    props: ['dropdowns', 'invoices', 'user', 'isExternal'],
+    components: { PageHeader, Pagination, Multiselect, CreateFromReceipt, Cancel, Adjustment, Approval, ReturnHistory },
+    props: ['dropdowns', 'invoices', 'user', 'isExternal', 'returnGracePeriod'],
     data(){
         return {
+            activeSubTab: 'list',
+            gracePeriod: this.returnGracePeriod || 7,
+            showSettings: false,
+            settingsSaving: false,
+            settingsForm: { gracePeriod: this.returnGracePeriod || 7 },
             currentUrl: window.location.origin,
             lists: [],
             meta: {},
@@ -225,7 +382,7 @@ export default {
             filter: {
                 keyword: null,
                 location_id: null,
-                status: ['sales-returned', 'sales-return-approval']
+                status: ['sales-returned', 'sales-return-approval', 'partially-returned']
             },
             index: null,
             selectedRow: null,
@@ -249,6 +406,10 @@ export default {
         canApprove() {
             const roles = this.$page?.props?.roles || [];
             return ['Administrator', 'Area Business Manager', 'Super Admin'].some(r => roles.includes(r));
+        },
+        isAdmin() {
+            const roles = this.$page?.props?.roles || [];
+            return ['Administrator', 'Super Admin'].some(r => roles.includes(r));
         },
     },
     created() {
@@ -282,6 +443,20 @@ export default {
         openCreate() {
             this.$refs.create.show();
         },
+        openSettings() {
+            this.settingsForm.gracePeriod = this.gracePeriod;
+            this.showSettings = true;
+        },
+        saveSettings() {
+            this.settingsSaving = true;
+            axios.patch('/app-settings/return_grace_period', { value: this.settingsForm.gracePeriod })
+                .then(() => {
+                    this.gracePeriod = this.settingsForm.gracePeriod;
+                    this.showSettings = false;
+                })
+                .catch(err => console.error('Failed to save setting', err))
+                .finally(() => { this.settingsSaving = false; });
+        },
 
 
 
@@ -297,7 +472,7 @@ export default {
 
         onApprove(data) {
             const route = this.isExternal ? '/sales-orders-external' : '/sales-orders';
-            this.$refs.approval.show(data.id, data.so_number, route, data.items || [], data.return_item_ids || [], data.return_items || {}, data.return_conditions || {});
+            this.$refs.approval.show(data.id, data.so_number, route, data.items || [], data.return_item_ids || [], data.return_items || {}, data.return_conditions || {}, data.payment_mode || '');
         },
     
 
@@ -372,6 +547,20 @@ export default {
 }
 </script>
 <style scoped>
+.sub-tab-btn {
+    padding: 6px 16px;
+    border-radius: 8px;
+    border: 1px solid #c4d9d2;
+    background: #fff;
+    color: #6b8c85;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.sub-tab-btn:hover { background: #edf6f2; color: #16322e; }
+.sub-tab-btn.active { background: #3D8D7A; border-color: #3D8D7A; color: #fff; }
+
 /* Modern Collapsible Row Styles */
 .main-table-row {
     cursor: pointer;
@@ -558,4 +747,77 @@ export default {
         width: 100%;
     }
 }
+
+/* ── Detail card redesign ─────────────────────────────────── */
+.det-card {
+    background: #fff;
+    border: 1px solid #e2ece8;
+    border-radius: 12px;
+    overflow: hidden;
+    height: 100%;
+}
+.det-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: linear-gradient(to right, #edf6f2, #f6fbf9);
+    border-bottom: 1px solid #dceee8;
+    font-size: 12px;
+    font-weight: 700;
+    color: #2a6b58;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+}
+.det-card-header i { font-size: 15px; color: #3d8d7a; }
+.det-card-body { padding: 4px 0; }
+.det-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 14px;
+    border-bottom: 1px dashed #f0f4f2;
+    font-size: 12px;
+}
+.det-row:last-child { border-bottom: none; }
+.det-label { color: #7a9b90; font-weight: 500; }
+.det-value { color: #1e3d33; font-weight: 600; text-align: right; }
+.det-divider { height: 1px; background: #e2ece8; margin: 4px 0; }
+.det-receipt-row { background: #fafcfb; }
+.mode-pill {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 20px;
+    font-size: 11px;
+    font-weight: 600;
+}
+.mode-cash { background: #e8f5e9; color: #2e7d32; }
+.mode-credit { background: #e3f2fd; color: #1565c0; }
+.rcpt-badge {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 20px;
+    font-size: 10px;
+    font-weight: 600;
+}
+.ret-badge {
+    display: inline-block;
+    background: #fff3e0;
+    color: #e65100;
+    border-radius: 20px;
+    padding: 1px 8px;
+    font-size: 11px;
+    font-weight: 700;
+}
+.det-items-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.det-items-table thead th {
+    background: #f5f9f7;
+    color: #5a7e72;
+    font-weight: 700;
+    font-size: 11px;
+    padding: 7px 10px;
+    border-bottom: 1px solid #dceee8;
+}
+.det-items-table tbody td { padding: 8px 10px; border-bottom: 1px dashed #f0f4f2; }
+.det-items-table tbody tr:last-child td { border-bottom: none; }
 </style>

--- a/resources/js/Pages/Modules/Sales/Components/SalesReturns/Modals/Approval.vue
+++ b/resources/js/Pages/Modules/Sales/Components/SalesReturns/Modals/Approval.vue
@@ -49,14 +49,10 @@
                             <thead>
                                 <tr>
                                     <th class="col-check">
-                                        <input
-                                            type="checkbox"
-                                            :checked="allItemsSelected"
-                                            @change="toggleAll"
-                                        >
+                                        <input type="checkbox" :checked="allItemsSelected" @change="toggleAll">
                                     </th>
                                     <th>Product</th>
-                                    <th>Sold Qty</th>
+                                    <th>Returnable Qty</th>
                                     <th>Return Qty</th>
                                     <th>Condition</th>
                                     <th>Unit</th>
@@ -67,28 +63,103 @@
                             <tbody>
                                 <tr v-for="item in items" :key="item.id">
                                     <td>
-                                        <input
-                                            type="checkbox"
-                                            v-model="selectedItems"
-                                            :value="item.id"
-                                        >
+                                        <input type="checkbox" v-model="selectedItems" :value="item.id">
                                     </td>
                                     <td>{{ getProductName(item.product_id) }}</td>
-                                    <td>{{ item.quantity }}</td>
-                                    <td>{{ getReturnQuantity(item.id, item.quantity) }}</td>
+                                    <td>{{ item.quantity - (item.returned_quantity || 0) }}</td>
+                                    <td>{{ getReturnQuantity(item.id, item.quantity - (item.returned_quantity || 0)) }}</td>
                                     <td>{{ formatCondition(getReturnCondition(item.id)) }}</td>
                                     <td>{{ item.unit }}</td>
                                     <td>{{ formatCurrency(item.price) }}</td>
-                                    <td class="fw-semibold">{{ formatCurrency(getReturnQuantity(item.id, item.quantity) * (item.price - (item.discount_per_unit || 0))) }}</td>
+                                    <td class="fw-semibold">{{ formatCurrency(getReturnQuantity(item.id, item.quantity - (item.returned_quantity || 0)) * (item.price - (item.discount_per_unit || 0))) }}</td>
                                 </tr>
                             </tbody>
                             <tfoot v-if="items.length > 0">
                                 <tr>
-                                    <td colspan="7" class="text-end fw-bold">Selected Total:</td>
-                                    <td class="fw-bold text-success">{{ formatCurrency(selectedTotal) }}</td>
+                                    <td colspan="7" class="text-end fw-bold">Return Value:</td>
+                                    <td class="fw-bold text-danger">{{ formatCurrency(selectedTotal) }}</td>
                                 </tr>
                             </tfoot>
                         </table>
+                    </div>
+                </div>
+
+                <!-- Replacement Items -->
+                <div class="table-wrap mt-3">
+                    <div class="table-toolbar">
+                        <h6 class="mb-0">Replacement Items</h6>
+                        <button type="button" class="btn btn-sm btn-outline-success" @click="addReplacementRow">
+                            <i class="ri-add-line me-1"></i> Add Item
+                        </button>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0 pretty-table">
+                            <thead>
+                                <tr>
+                                    <th>Product</th>
+                                    <th style="width:120px">Qty</th>
+                                    <th style="width:130px">Unit Price</th>
+                                    <th style="width:130px">Total</th>
+                                    <th style="width:44px"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="(row, i) in replacementRows" :key="i">
+                                    <td>
+                                        <select v-model="row.product_id" @change="onReplacementProductChange(row)" class="form-select form-select-sm">
+                                            <option :value="null">Select product...</option>
+                                            <option v-for="p in productsWithStock" :key="p.value" :value="p.value">{{ p.name }}</option>
+                                        </select>
+                                    </td>
+                                    <td>
+                                        <input type="number" v-model.number="row.quantity" min="1" class="form-control form-control-sm" placeholder="Qty">
+                                    </td>
+                                    <td>
+                                        <input type="number" v-model.number="row.price" min="0" step="0.01" class="form-control form-control-sm" placeholder="Price">
+                                    </td>
+                                    <td class="fw-semibold">{{ formatCurrency((row.quantity || 0) * (row.price || 0)) }}</td>
+                                    <td>
+                                        <button type="button" class="btn btn-sm btn-outline-danger" @click="removeReplacementRow(i)">
+                                            <i class="ri-delete-bin-line"></i>
+                                        </button>
+                                    </td>
+                                </tr>
+                                <tr v-if="replacementRows.length === 0">
+                                    <td colspan="5" class="text-center text-muted small py-2">No replacement items added yet.</td>
+                                </tr>
+                            </tbody>
+                            <tfoot v-if="replacementRows.length > 0">
+                                <tr>
+                                    <td colspan="3" class="text-end fw-bold">Replacement Value:</td>
+                                    <td class="fw-bold text-success">{{ formatCurrency(replacementTotal) }}</td>
+                                    <td></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+
+                    <!-- Under-value warning -->
+                    <div v-if="replacementUndervalue" class="alert-undervalue mt-2">
+                        <i class="ri-error-warning-line"></i>
+                        Replacement value ({{ formatCurrency(replacementTotal) }}) must be equal to or greater than the return value ({{ formatCurrency(selectedTotal) }}). No under-value replacements allowed.
+                    </div>
+
+                    <!-- Cash return summary -->
+                    <div class="cash-return-summary mt-3">
+                        <div class="crs-row">
+                            <span>Return Value</span>
+                            <span class="text-danger">- {{ formatCurrency(selectedTotal) }}</span>
+                        </div>
+                        <div class="crs-row">
+                            <span>Replacement Value</span>
+                            <span class="text-success">+ {{ formatCurrency(replacementTotal) }}</span>
+                        </div>
+                        <div class="crs-row crs-total">
+                            <span>Extra to Collect</span>
+                            <span :class="extraAmount > 0 ? 'text-primary fw-bold' : 'text-muted'">
+                                {{ extraAmount > 0 ? formatCurrency(extraAmount) : 'None' }}
+                            </span>
+                        </div>
                     </div>
                 </div>
 
@@ -131,34 +202,53 @@ export default {
                 id: null,
                 action: 'approve',
                 item_ids: [],
+                replacement_items: [],
             }),
             so_number: null,
+            paymentMode: '',
             text_confirm: '',
             showModal: false,
             items: [],
             selectedItems: [],
             returnItems: {},
             returnConditions: {},
+            replacementRows: [],
         }
     },
     computed: {
+        productsWithStock() {
+            return (this.products || []).filter(p => (p.available_quantity || 0) > 0);
+        },
+        isCashSale() {
+            const mode = (this.paymentMode || '').trim().toLowerCase();
+            return mode !== 'credit' && mode !== 'credit sales';
+        },
         allItemsSelected() {
             return this.items.length > 0 && this.selectedItems.length === this.items.length;
         },
         selectedTotal() {
             return this.items
                 .filter(item => this.selectedItems.includes(item.id))
-                .reduce((sum, item) => sum + (this.getReturnQuantity(item.id, item.quantity) * (item.price - (item.discount_per_unit || 0))), 0);
+                .reduce((sum, item) => sum + (this.getReturnQuantity(item.id, item.quantity - (item.returned_quantity || 0)) * (item.price - (item.discount_per_unit || 0))), 0);
+        },
+        replacementTotal() {
+            return this.replacementRows.reduce((sum, row) => sum + ((row.quantity || 0) * (row.price || 0)), 0);
+        },
+        extraAmount() {
+            return Math.max(0, this.replacementTotal - this.selectedTotal);
+        },
+        replacementUndervalue() {
+            return this.replacementRows.length > 0 && this.replacementTotal < this.selectedTotal;
         },
         confirmTextValid() {
             return (this.text_confirm || '').trim().toUpperCase() === 'CONFIRM';
         },
         isValid() {
-            return this.selectedItems.length > 0 && this.confirmTextValid && !this.form.processing;
+            return this.selectedItems.length > 0 && this.confirmTextValid && !this.form.processing && !this.replacementUndervalue;
         }
     },
     methods: {
-        show(id, so_number, route, items = [], preselectedItemIds = [], returnItems = {}, returnConditions = {}){
+        show(id, so_number, route, items = [], preselectedItemIds = [], returnItems = {}, returnConditions = {}, paymentMode = ''){
             this.form.reset();
             this.form.clearErrors();
             this.showModal = true;
@@ -166,18 +256,34 @@ export default {
             this.so_number = so_number;
             this.route = route;
             this.items = items;
+            this.paymentMode = paymentMode;
             this.returnItems = returnItems || {};
             this.returnConditions = returnConditions || {};
+            this.replacementRows = [];
             this.selectedItems = preselectedItemIds.length > 0
                 ? preselectedItemIds
                 : items.map(item => item.id);
             this.text_confirm = '';
         },
 
+        addReplacementRow() {
+            this.replacementRows.push({ product_id: null, quantity: 1, price: 0 });
+        },
+        removeReplacementRow(index) {
+            this.replacementRows.splice(index, 1);
+        },
+        onReplacementProductChange(row) {
+            const product = (this.products || []).find(p => p.value === row.product_id);
+            if (product) {
+                row.price = product.retail_price || product.price || 0;
+            }
+        },
+
         submit(){
             if (!this.isValid) return;
 
             this.form.item_ids = this.selectedItems;
+            this.form.replacement_items = this.replacementRows.filter(r => r.product_id && r.quantity > 0);
             this.form.put(`${this.route}/${this.form.id}`,{
                 preserveScroll: true,
                 onSuccess: (response) => {
@@ -200,6 +306,8 @@ export default {
             this.selectedItems = [];
             this.returnItems = {};
             this.returnConditions = {};
+            this.replacementRows = [];
+            this.paymentMode = '';
             this.text_confirm = '';
         },
         toggleAll(){
@@ -337,6 +445,38 @@ export default {
     color: #2f4a3f;
     border-radius: 6px;
     padding: 2px 6px;
+}
+
+.alert-undervalue {
+    background: #fff5f5;
+    border: 1px solid #ffc5c5;
+    color: #c0392b;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.cash-return-summary {
+    background: #f8fbfa;
+    border: 1px solid #e2e8e5;
+    border-radius: 10px;
+    padding: 12px 16px;
+}
+.crs-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px 0;
+    font-size: 13px;
+    border-bottom: 1px dashed #e2e8e5;
+}
+.crs-row:last-child { border-bottom: none; }
+.crs-total {
+    font-size: 14px;
+    padding-top: 8px;
+    margin-top: 4px;
 }
 
 .pretty-footer {

--- a/resources/js/Pages/Modules/Sales/Components/SalesReturns/Modals/CreateFromReceipt.vue
+++ b/resources/js/Pages/Modules/Sales/Components/SalesReturns/Modals/CreateFromReceipt.vue
@@ -151,16 +151,16 @@
                                                     </div>
                                                 </td>
                                                 <td><span class="batch-pill">{{ item.batch_code || '-' }}</span></td>
-                                                <td class="text-center"><span class="qty-pill">{{ item.quantity }}</span></td>
+                                                <td class="text-center"><span class="qty-pill">{{ returnableQty(item) }}</span></td>
                                                 <td class="text-center">
                                                     <input
                                                         type="number"
                                                         class="form-control form-control-sm return-qty-input"
                                                         :value="getReturnQuantity(item.id)"
                                                         :min="isItemSelected(item.id) ? 1 : 0"
-                                                        :max="item.quantity"
+                                                        :max="returnableQty(item)"
                                                         :disabled="!isItemSelected(item.id)"
-                                                        @input="updateReturnQuantity(item.id, $event.target.value, item.quantity)"
+                                                        @input="updateReturnQuantity(item.id, $event.target.value, returnableQty(item))"
                                                     >
                                                 </td>
                                                 <td class="text-center">
@@ -229,7 +229,7 @@ import axios from 'axios';
 import { useForm } from '@inertiajs/vue3';
 
 export default {
-    props: ['dropdowns'],
+    props: ['dropdowns', 'returnGracePeriod'],
     data() {
         return {
             showModal: false,
@@ -255,8 +255,21 @@ export default {
     computed: {
         filteredReceipts() {
             const keyword = (this.receiptKeyword || '').trim().toLowerCase();
+            const windowDays = this.returnGracePeriod || 7;
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - windowDays);
+            cutoff.setHours(0, 0, 0, 0);
 
             return this.receipts.filter((receipt) => {
+                // Only payment-type receipts that aren't cancelled
+                if (receipt.receipt_type !== 'payment') return false;
+                if (receipt.status?.slug === 'cancelled') return false;
+
+                // Within return grace period window
+                const receiptDate = receipt.receipt_date ? new Date(receipt.receipt_date) : null;
+                if (!receiptDate || receiptDate < cutoff) return false;
+
+                // Sales order must exist and not be in a blocked status
                 if (!receipt?.sales_order || this.isBlockedStatus(receipt.sales_order.status?.slug)) {
                     return false;
                 }
@@ -348,10 +361,11 @@ export default {
             try {
                 const res = await axios.get(`/receipts/${receipt.id}`, { params: { option: 'detail' } });
                 this.receiptDetail = res.data?.data ?? res.data;
-                const items = this.receiptDetail?.sales_order?.items || [];
+                const allItems = this.receiptDetail?.sales_order?.items || [];
+                const items = allItems.filter(item => (item.quantity - (item.returned_quantity || 0)) > 0);
                 this.form.id = this.receiptDetail?.sales_order?.id || null;
                 this.form.item_ids = items.map(item => item.id);
-                this.form.return_quantities = items.reduce((q, item) => { q[item.id] = item.quantity; return q; }, {});
+                this.form.return_quantities = items.reduce((q, item) => { q[item.id] = item.quantity - (item.returned_quantity || 0); return q; }, {});
                 this.form.return_conditions = items.reduce((c, item) => { c[item.id] = 'restockable'; return c; }, {});
             } catch (e) {
                 console.error('Failed to load receipt detail', e);
@@ -411,6 +425,9 @@ export default {
             }
             return `${policy.window_days} day window`;
         },
+        returnableQty(item) {
+            return Math.max(0, (item.quantity || 0) - (item.returned_quantity || 0));
+        },
         isItemSelected(itemId) {
             return Number(this.form.return_quantities?.[itemId] || 0) > 0;
         },
@@ -424,7 +441,7 @@ export default {
             if (this.isItemSelected(item.id)) {
                 this.form.return_quantities[item.id] = 0;
             } else {
-                this.form.return_quantities[item.id] = item.quantity;
+                this.form.return_quantities[item.id] = item.quantity - (item.returned_quantity || 0);
                 if (!this.form.return_conditions[item.id]) {
                     this.form.return_conditions[item.id] = 'restockable';
                 }
@@ -453,7 +470,7 @@ export default {
         },
         toggleAllItems() {
             this.form.return_quantities = this.selectedItems.reduce((quantities, item) => {
-                quantities[item.id] = this.allItemsSelected ? 0 : item.quantity;
+                quantities[item.id] = this.allItemsSelected ? 0 : item.quantity - (item.returned_quantity || 0);
                 return quantities;
             }, {});
             this.syncSelectedItems();

--- a/resources/js/Pages/Modules/Sales/Components/SalesReturns/ReturnHistory.vue
+++ b/resources/js/Pages/Modules/Sales/Components/SalesReturns/ReturnHistory.vue
@@ -1,0 +1,220 @@
+<template>
+    <div>
+        <div class="col-lg-12 mb-4">
+            <div class="library-card">
+                <div class="library-card-header">
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="header-icon">
+                            <i class="ri-history-line fs-24"></i>
+                        </div>
+                        <div>
+                            <h4 class="header-title mb-1">Returns History</h4>
+                            <p class="header-subtitle mb-0">Approved return breakdown — restocked vs. written off</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="library-card-body">
+                    <!-- Filters -->
+                    <div class="search-section mb-3">
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold">From</label>
+                                <input type="date" v-model="filter.from" class="form-control form-control-sm" @change="fetch()">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold">To</label>
+                                <input type="date" v-model="filter.to" class="form-control form-control-sm" @change="fetch()">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label small fw-semibold">Condition</label>
+                                <select v-model="filter.condition" class="form-select form-select-sm" @change="fetch()">
+                                    <option :value="null">All Conditions</option>
+                                    <option value="restockable">Restockable</option>
+                                    <option value="damaged">Damaged</option>
+                                    <option value="loss">Loss</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Summary Boxes -->
+                    <div class="row g-3 mb-4" v-if="summary">
+                        <div class="col-md-4">
+                            <div class="summary-card restockable">
+                                <div class="summary-icon"><i class="ri-refresh-line"></i></div>
+                                <div class="summary-body">
+                                    <div class="summary-label">Restocked</div>
+                                    <div class="summary-value">{{ formatCurrency(summary.restockable?.value || 0) }}</div>
+                                    <div class="summary-sub">{{ summary.restockable?.qty || 0 }} units returned to stock</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="summary-card damaged">
+                                <div class="summary-icon"><i class="ri-error-warning-line"></i></div>
+                                <div class="summary-body">
+                                    <div class="summary-label">Damaged / Written Off</div>
+                                    <div class="summary-value">{{ formatCurrency(summary.damaged?.value || 0) }}</div>
+                                    <div class="summary-sub">{{ summary.damaged?.qty || 0 }} units written off</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="summary-card loss">
+                                <div class="summary-icon"><i class="ri-close-circle-line"></i></div>
+                                <div class="summary-body">
+                                    <div class="summary-label">Loss</div>
+                                    <div class="summary-value">{{ formatCurrency(summary.loss?.value || 0) }}</div>
+                                    <div class="summary-sub">{{ summary.loss?.qty || 0 }} units recorded as loss</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Table -->
+                    <div class="table-responsive">
+                        <table class="table sales-table mb-0">
+                            <thead>
+                                <tr>
+                                    <th style="width:3%">#</th>
+                                    <th>SO Number</th>
+                                    <th>Customer</th>
+                                    <th>Product</th>
+                                    <th class="text-center">Qty</th>
+                                    <th class="text-center">Condition</th>
+                                    <th class="text-end">Unit Price</th>
+                                    <th class="text-end">Total Value</th>
+                                    <th class="text-center">Date</th>
+                                    <th class="text-center">Approved By</th>
+                                </tr>
+                            </thead>
+                            <tbody class="fs-12">
+                                <tr v-for="(row, i) in rows" :key="row.id">
+                                    <td>{{ i + 1 }}</td>
+                                    <td class="fw-semibold">{{ row.so_number }}</td>
+                                    <td>{{ row.customer || '-' }}</td>
+                                    <td>{{ row.product || '-' }}</td>
+                                    <td class="text-center">{{ row.quantity }}</td>
+                                    <td class="text-center">
+                                        <span class="condition-badge" :class="row.condition">
+                                            {{ conditionLabel(row.condition) }}
+                                        </span>
+                                    </td>
+                                    <td class="text-end">{{ formatCurrency(row.unit_price) }}</td>
+                                    <td class="text-end fw-semibold">{{ formatCurrency(row.total_value) }}</td>
+                                    <td class="text-center">{{ row.returned_at }}</td>
+                                    <td class="text-center">{{ row.approved_by || '-' }}</td>
+                                </tr>
+                                <tr v-if="rows.length === 0">
+                                    <td colspan="10">
+                                        <div class="sales-empty-state">
+                                            <i class="ri-history-line"></i>
+                                            <p>No return history found.</p>
+                                            <small>Approved returns will appear here.</small>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: ['isExternal'],
+    data() {
+        const today = new Date();
+        const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().split('T')[0];
+        const todayStr = today.toISOString().split('T')[0];
+        return {
+            filter: {
+                from: firstOfMonth,
+                to: todayStr,
+                condition: null,
+            },
+            rows: [],
+            summary: null,
+        };
+    },
+    created() {
+        this.fetch();
+    },
+    methods: {
+        fetch() {
+            const url = this.isExternal ? '/sales-orders-external' : '/sales-orders';
+            axios.get(url, {
+                params: {
+                    option: 'return-history',
+                    from: this.filter.from,
+                    to: this.filter.to,
+                    condition: this.filter.condition,
+                }
+            }).then(res => {
+                this.rows = res.data.rows || [];
+                this.summary = res.data.summary || null;
+            }).catch(err => console.error(err));
+        },
+        formatCurrency(value) {
+            return '₱' + Number(value || 0).toLocaleString('en-PH', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+            });
+        },
+        conditionLabel(cond) {
+            const map = { restockable: 'Restockable', damaged: 'Damaged', loss: 'Loss' };
+            return map[cond] || cond;
+        },
+    }
+}
+</script>
+
+<style scoped>
+.summary-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 1px solid #e9ecef;
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.summary-card.restockable { border-left: 4px solid #3D8D7A; }
+.summary-card.damaged     { border-left: 4px solid #e67e22; }
+.summary-card.loss        { border-left: 4px solid #e74c3c; }
+
+.summary-icon {
+    font-size: 1.5rem;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    flex-shrink: 0;
+}
+.restockable .summary-icon { background: rgba(61,141,122,0.1); color: #3D8D7A; }
+.damaged     .summary-icon { background: rgba(230,126,34,0.1); color: #e67e22; }
+.loss        .summary-icon { background: rgba(231,76,60,0.1);  color: #e74c3c; }
+
+.summary-label { font-size: 0.75rem; color: #6c757d; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+.summary-value { font-size: 1.25rem; font-weight: 700; color: #2b3459; }
+.summary-sub   { font-size: 0.75rem; color: #6c757d; }
+
+.condition-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 20px;
+    font-size: 11px;
+    font-weight: 600;
+}
+.condition-badge.restockable { background: rgba(61,141,122,0.12); color: #3D8D7A; }
+.condition-badge.damaged     { background: rgba(230,126,34,0.12); color: #e67e22; }
+.condition-badge.loss        { background: rgba(231,76,60,0.12);  color: #e74c3c; }
+</style>

--- a/resources/js/Pages/Modules/Sales/Index.vue
+++ b/resources/js/Pages/Modules/Sales/Index.vue
@@ -71,7 +71,7 @@
               <div v-if="activeTab === 'sales_returns'" class="row">
                 <div :class="isRightSidebarCollapsed ? 'col-md-12' : 'col-md-9'">
                  
-                    <SalesReturns :dropdowns="dropdowns" />
+                    <SalesReturns :dropdowns="dropdowns" :returnGracePeriod="return_grace_period || 7" />
                 
                 </div>
                 <div v-show="!isRightSidebarCollapsed" class="col-md-3">
@@ -171,7 +171,7 @@ import StockSidebar from "@/Pages/Modules/Sales/Components/StockSidebar.vue";
 
 export default {
   components: { PageHeader, Pagination, SalesOrders, SalesReturns, ARInvoices, Receipts, Remittances, SalesReports, QuickStatsSidebar, StockSidebar },
-  props: ['dropdowns'],
+  props: ['dropdowns', 'return_grace_period'],
   data() {
     return {
       isSidebarCollapsed: false,

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,10 @@ Route::middleware(['2fa','auth','is_active'])->group(function () {
         Route::post('/inventory-stocks/{id}/settings', [App\Http\Controllers\InventoryStockController::class, 'settings']);
     });
 
+    Route::middleware(['role:Administrator,Super Admin'])->group(function () {
+        Route::patch('/app-settings/{key}', [App\Http\Controllers\AppSettingController::class, 'update']);
+    });
+
     Route::middleware(['role:Administrator'])->group(function () {
         // Route::get('/receipts', [App\Http\Controllers\Libraries\ReceiptController::class, 'index']);
         // Route::get('/receipts/{id}/print', [App\Http\Controllers\Libraries\ReceiptController::class, 'print']);

--- a/tests/Feature/Libraries/ReceiptStatusPreservationTest.php
+++ b/tests/Feature/Libraries/ReceiptStatusPreservationTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Tests\Feature\Libraries;
+
+use App\Models\ArInvoice;
+use App\Models\Customer;
+use App\Models\ListStatus;
+use App\Models\Receipt;
+use App\Models\SalesOrder;
+use App\Models\User;
+use App\Services\Libraries\ReceiptClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Guards against ReceiptClass overwriting partially-returned / sales-returned
+ * SO status when a receipt is added, updated, or deleted.
+ */
+class ReceiptStatusPreservationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Customer $customer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        foreach ([
+            'partially-returned', 'sales-returned', 'partially-paid',
+            'paid', 'unpaid', 'pending', 'closed', 'for-payment',
+        ] as $slug) {
+            ListStatus::firstOrCreate(['slug' => $slug], [
+                'name'       => ucwords(str_replace('-', ' ', $slug)),
+                'text_color' => '#fff',
+                'bg_color'   => '#333',
+            ]);
+        }
+
+        $this->customer = Customer::create([
+            'name'           => 'Test Customer',
+            'address'        => 'Addr',
+            'contact_number' => '09000000001',
+            'added_by_id'    => $this->user->id,
+            'is_active'      => true,
+            'is_regular'     => false,
+            'is_blacklisted' => false,
+        ]);
+    }
+
+    private function makeSoWithInvoice(string $statusSlug, float $amountDue, float $amountPaid, float $balanceDue): array
+    {
+        $so = SalesOrder::create([
+            'so_number'    => 'SO-RCPT-' . uniqid(),
+            'order_date'   => now()->toDateString(),
+            'customer_id'  => $this->customer->id,
+            'status_id'    => ListStatus::where('slug', $statusSlug)->first()->id,
+            'total_amount' => $amountDue,
+            'payment_mode' => 'cash',
+            'added_by_id'  => $this->user->id,
+        ]);
+
+        $invoice = ArInvoice::create([
+            'sales_order_id' => $so->id,
+            'status_id'      => ListStatus::where('slug', $amountPaid >= $amountDue ? 'paid' : 'partially-paid')->first()->id,
+            'invoice_number' => 'INV-' . $so->so_number,
+            'invoice_date'   => now()->toDateString(),
+            'amount_due'     => $amountDue,
+            'amount_paid'    => $amountPaid,
+            'balance_due'    => $balanceDue,
+        ]);
+
+        return [$so, $invoice];
+    }
+
+    private function makeReceipt(ArInvoice $invoice, float $amountPaid, string $statusSlug = 'paid'): Receipt
+    {
+        return Receipt::create([
+            'ar_invoice_id'  => $invoice->id,
+            'customer_id'    => $this->customer->id,
+            'status_id'      => ListStatus::where('slug', $statusSlug)->first()->id,
+            'receipt_number' => 'REC-' . uniqid(),
+            'receipt_type'   => 'payment',
+            'receipt_date'   => now()->toDateString(),
+            'amount_paid'    => $amountPaid,
+            'payment_mode'   => 'cash',
+        ]);
+    }
+
+    // ─── save() ──────────────────────────────────────────────────────────────
+
+    public function test_adding_receipt_preserves_partially_returned_status(): void
+    {
+        // SO is partially-returned, ₱1,000 balance remaining (replacement extra charge)
+        [$so, $invoice] = $this->makeSoWithInvoice('partially-returned', 3000, 2000, 1000);
+
+        $request = new Request();
+        $request->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 500.00,
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($request);
+
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug,
+            'Adding a receipt must not overwrite partially-returned SO status');
+    }
+
+    public function test_adding_receipt_preserves_sales_returned_status(): void
+    {
+        [$so, $invoice] = $this->makeSoWithInvoice('sales-returned', 2000, 1000, 1000);
+
+        $request = new Request();
+        $request->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 500.00,
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($request);
+
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug,
+            'Adding a receipt must not overwrite sales-returned SO status');
+    }
+
+    public function test_adding_receipt_that_fully_pays_returned_so_marks_it_closed(): void
+    {
+        // If the customer pays off the full remaining balance on a returned SO, it should close
+        [$so, $invoice] = $this->makeSoWithInvoice('partially-returned', 2000, 1000, 1000);
+
+        $request = new Request();
+        $request->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 1000.00, // clears the balance
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($request);
+
+        $this->assertEquals('closed', $so->fresh()->status->slug,
+            'Fully paying a returned SO must mark it closed');
+    }
+
+    public function test_paying_off_sales_returned_so_keeps_it_sales_returned(): void
+    {
+        // sales-returned SO with an extra replacement charge that is now being paid off
+        [$so, $invoice] = $this->makeSoWithInvoice('sales-returned', 500, 0, 500);
+
+        $request = new Request();
+        $request->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 500.00, // clears the full balance
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($request);
+
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug,
+            'Paying off a sales-returned SO must NOT mark it closed — it stays sales-returned');
+    }
+
+    // ─── update() ────────────────────────────────────────────────────────────
+
+    public function test_updating_receipt_preserves_partially_returned_status(): void
+    {
+        [$so, $invoice] = $this->makeSoWithInvoice('partially-returned', 3000, 1000, 2000);
+        $receipt = $this->makeReceipt($invoice, 1000, 'paid');
+
+        $request = new Request();
+        $request->merge([
+            'id'            => $receipt->id,
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 800.00, // reduce the payment slightly
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->update($request);
+
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug,
+            'Updating a receipt must not overwrite partially-returned SO status');
+    }
+
+    // ─── delete() ────────────────────────────────────────────────────────────
+
+    public function test_deleting_receipt_preserves_partially_returned_status(): void
+    {
+        [$so, $invoice] = $this->makeSoWithInvoice('partially-returned', 3000, 1000, 2000);
+        $receipt = $this->makeReceipt($invoice, 1000, 'paid');
+
+        app(ReceiptClass::class)->delete($receipt->id);
+
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug,
+            'Deleting a receipt must not overwrite partially-returned SO status');
+    }
+
+    public function test_deleting_receipt_preserves_sales_returned_status(): void
+    {
+        [$so, $invoice] = $this->makeSoWithInvoice('sales-returned', 2000, 1000, 1000);
+        $receipt = $this->makeReceipt($invoice, 1000, 'paid');
+
+        app(ReceiptClass::class)->delete($receipt->id);
+
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug,
+            'Deleting a receipt must not overwrite sales-returned SO status');
+    }
+
+    // ─── Regression: non-returned SO still updates normally ──────────────────
+
+    public function test_adding_receipt_still_marks_non_returned_so_as_partially_paid(): void
+    {
+        [$so, $invoice] = $this->makeSoWithInvoice('for-payment', 3000, 0, 3000);
+
+        $request = new Request();
+        $request->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => 1000.00,
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($request);
+
+        $this->assertEquals('partially-paid', $so->fresh()->status->slug,
+            'Normal (non-returned) SO must still become partially-paid after partial payment');
+    }
+}

--- a/tests/Feature/SalesReturn/ComplexReturnScenariosTest.php
+++ b/tests/Feature/SalesReturn/ComplexReturnScenariosTest.php
@@ -1,0 +1,618 @@
+<?php
+
+namespace Tests\Feature\SalesReturn;
+
+use App\Models\ArInvoice;
+use App\Models\Customer;
+use App\Models\InventoryStocks;
+use App\Models\JournalEntry;
+use App\Models\JournalEntryLine;
+use App\Models\ListStatus;
+use App\Models\Product;
+use App\Models\Receipt;
+use App\Models\ReceivedItem;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderItem;
+use App\Models\SalesReturnHistory;
+use App\Models\SalesReturnReplacement;
+use App\Models\User;
+use App\Services\Libraries\ReceiptClass;
+use App\Services\Modules\SalesOrderClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class ComplexReturnScenariosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Product $product;
+    private Product $productB;
+    private Customer $customer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        foreach ([
+            'sales-return-approval', 'sales-returned', 'partially-returned',
+            'paid', 'cancelled', 'closed', 'for-payment', 'unpaid',
+            'partially-paid', 'pending', 'liquidated', 'approved',
+        ] as $slug) {
+            ListStatus::firstOrCreate(['slug' => $slug], [
+                'name'       => ucwords(str_replace('-', ' ', $slug)),
+                'text_color' => '#fff',
+                'bg_color'   => '#333',
+            ]);
+        }
+
+        $unitId  = \DB::table('list_units')->insertGetId(['name' => 'Sack', 'created_at' => now(), 'updated_at' => now()]);
+        $brandId = \DB::table('list_brands')->insertGetId(['name' => 'Brand', 'created_at' => now(), 'updated_at' => now()]);
+
+        $this->product  = Product::create(['code' => 'P1-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true]);
+        $this->productB = Product::create(['code' => 'P2-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true]);
+
+        $this->customer = Customer::create([
+            'name' => 'Customer', 'address' => 'Addr', 'contact_number' => '09000000001',
+            'added_by_id' => $this->user->id, 'is_active' => true, 'is_regular' => false, 'is_blacklisted' => false,
+        ]);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeStock(Product $product, string $batch, float $cost, int $qty): InventoryStocks
+    {
+        $supId = \DB::table('list_suppliers')->insertGetId([
+            'name' => 'S-' . $batch, 'address' => 'A', 'contact_person' => 'P',
+            'contact_number' => '0', 'email' => 'x@x.com', 'tin' => '0',
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $stId  = ListStatus::where('slug', 'paid')->first()->id;
+        $poId  = \DB::table('purchase_orders')->insertGetId([
+            'supplier_id' => $supId, 'status_id' => $stId, 'created_by_id' => $this->user->id,
+            'po_date' => now()->toDateString(), 'total_amount' => ($qty + 10) * $cost,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $piId  = \DB::table('purchase_order_items')->insertGetId([
+            'po_id' => $poId, 'product_id' => $product->id,
+            'quantity' => $qty + 10, 'unit_cost' => $cost, 'total_cost' => ($qty + 10) * $cost,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $rsId  = \DB::table('received_stocks')->insertGetId([
+            'po_id' => $poId, 'supplier_id' => $supId, 'received_date' => now()->toDateString(),
+            'received_no' => 'RS-' . $batch, 'payment_mode' => 'cash', 'amount_paid' => 0,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $ri = ReceivedItem::create([
+            'received_id' => $rsId, 'product_id' => $product->id,
+            'quantity' => $qty + 10, 'unit_cost' => $cost, 'total_cost' => ($qty + 10) * $cost,
+            'po_item_id' => $piId,
+        ]);
+        return InventoryStocks::create([
+            'received_item_id' => $ri->id,
+            'quantity'         => $qty,
+            'retail_price'     => $cost * 1.6,
+            'wholesale_price'  => $cost * 1.5,
+            'batch_code'       => $batch,
+        ]);
+    }
+
+    private function makeSo(string $mode, float $total, string $statusSlug = 'sales-return-approval'): SalesOrder
+    {
+        return SalesOrder::create([
+            'so_number'    => 'SO-CX-' . uniqid(),
+            'order_date'   => now()->toDateString(),
+            'customer_id'  => $this->customer->id,
+            'status_id'    => ListStatus::where('slug', $statusSlug)->first()->id,
+            'total_amount' => $total,
+            'payment_mode' => $mode,
+            'added_by_id'  => $this->user->id,
+        ]);
+    }
+
+    private function addItem(SalesOrder $so, InventoryStocks $stock, int $qty, float $price, int $returnedQty = 0): SalesOrderItem
+    {
+        $item = new SalesOrderItem([
+            'product_id'        => $stock->receivedItem->product_id,
+            'quantity'          => $qty,
+            'returned_quantity' => $returnedQty,
+            'price'             => $price,
+            'price_type'        => 'retail',
+            'batch_code'        => $stock->batch_code,
+            'discount_per_unit' => 0,
+        ]);
+        $item->sales_order_id = $so->id;
+        $item->save();
+        return $item;
+    }
+
+    private function makeInvoice(SalesOrder $so, float $due, float $paid, float $balance, string $slug = 'paid'): ArInvoice
+    {
+        return ArInvoice::create([
+            'sales_order_id' => $so->id,
+            'status_id'      => ListStatus::where('slug', $slug)->first()->id,
+            'invoice_number' => 'INV-' . $so->so_number,
+            'invoice_date'   => now()->toDateString(),
+            'amount_due'     => $due,
+            'amount_paid'    => $paid,
+            'balance_due'    => $balance,
+        ]);
+    }
+
+    private function makeReceipt(ArInvoice $inv, float $amount, string $slug = 'paid'): Receipt
+    {
+        return Receipt::create([
+            'ar_invoice_id'  => $inv->id,
+            'customer_id'    => $this->customer->id,
+            'status_id'      => ListStatus::where('slug', $slug)->first()->id,
+            'receipt_number' => 'REC-' . uniqid(),
+            'receipt_type'   => 'payment',
+            'receipt_date'   => now()->toDateString(),
+            'amount_paid'    => $amount,
+            'payment_mode'   => 'cash',
+        ]);
+    }
+
+    private function queueReturn(SalesOrderItem $item, Receipt $receipt, int $qty, string $condition = 'restockable'): void
+    {
+        \DB::table('sales_return_items')->insert([
+            'sales_order_item_id' => $item->id,
+            'source_receipt_id'   => $receipt->id,
+            'return_quantity'     => $qty,
+            'return_condition'    => $condition,
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ]);
+    }
+
+    private function assertJournalEntriesBalanced(): void
+    {
+        $entries = JournalEntry::with('lines')->get();
+        foreach ($entries as $entry) {
+            $debit  = $entry->lines->where('line_type', 'debit')->sum('amount');
+            $credit = $entry->lines->where('line_type', 'credit')->sum('amount');
+            $this->assertEquals(
+                round($debit, 2),
+                round($credit, 2),
+                "Journal entry #{$entry->id} (type: {$entry->entry_type}) is unbalanced: debit={$debit}, credit={$credit}"
+            );
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 1. Journal entries always balance
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_journal_entries_balanced_after_full_credit_return(): void
+    {
+        $stock   = $this->makeStock($this->product, 'JB-001', 400.00, 10);
+        $so      = $this->makeSo('credit', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $this->assertJournalEntriesBalanced();
+    }
+
+    public function test_journal_entries_balanced_after_partial_credit_return(): void
+    {
+        $stock   = $this->makeStock($this->product, 'JB-002', 400.00, 10);
+        $so      = $this->makeSo('credit', 4000.00);
+        $itemA   = $this->addItem($so, $stock, 2, 1000.00);
+        $itemB   = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 4000, 4000, 0);
+        $receipt = $this->makeReceipt($invoice, 4000);
+
+        $this->queueReturn($itemA, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id]);
+
+        $this->assertJournalEntriesBalanced();
+    }
+
+    public function test_journal_entries_balanced_after_cash_return_with_replacement(): void
+    {
+        $stock    = $this->makeStock($this->product,  'JB-003', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'JB-004', 500.00, 10);
+        $so       = $this->makeSo('cash', 2000.00);
+        $item     = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice  = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt  = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 2,
+            'price'      => 1000.00,
+        ]]);
+
+        $this->assertJournalEntriesBalanced();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 2. Mixed conditions in same return
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_mixed_restockable_and_damaged_creates_both_journal_entries(): void
+    {
+        $stock  = $this->makeStock($this->product, 'MX-001', 400.00, 10);
+        $so     = $this->makeSo('credit', 4000.00);
+        $itemA  = $this->addItem($so, $stock, 2, 1000.00);
+        $itemB  = $this->addItem($so, $stock, 2, 1000.00);
+        $inv    = $this->makeInvoice($so, 4000, 4000, 0);
+        $rcpt   = $this->makeReceipt($inv, 4000);
+
+        \DB::table('sales_return_items')->insert([
+            ['sales_order_item_id' => $itemA->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 2, 'return_condition' => 'restockable', 'created_at' => now(), 'updated_at' => now()],
+            ['sales_order_item_id' => $itemB->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 2, 'return_condition' => 'damaged', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id, $itemB->id]);
+
+        // Inventory restoration JE for restockable
+        $this->assertNotNull(
+            JournalEntry::where('entry_type', 'sales_return_inventory')->first(),
+            'Restockable item must create an inventory restoration JE'
+        );
+
+        // Damage write-off JE for damaged
+        $this->assertNotNull(
+            JournalEntry::where('entry_type', 'sales_return_damage_writeoff')->first(),
+            'Damaged item must create a damage write-off JE'
+        );
+
+        // Same product stock: restockable addStock(+2) then damaged recordLossOrDamage(-2) → net 0 change.
+        $this->assertEquals(10, $stock->fresh()->quantity,
+            'Net stock: 10 + 2 restockable - 2 damaged write-off = 10.');
+
+        $this->assertJournalEntriesBalanced();
+    }
+
+    public function test_mixed_conditions_inventory_adjustments_are_correct(): void
+    {
+        $stock  = $this->makeStock($this->product, 'MX-002', 400.00, 10);
+        $so     = $this->makeSo('credit', 4000.00);
+        $itemA  = $this->addItem($so, $stock, 2, 1000.00); // will be restockable
+        $itemB  = $this->addItem($so, $stock, 3, 1000.00); // will be damaged
+        $inv    = $this->makeInvoice($so, 5000, 5000, 0);
+        $rcpt   = $this->makeReceipt($inv, 5000);
+
+        \DB::table('sales_return_items')->insert([
+            ['sales_order_item_id' => $itemA->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 2, 'return_condition' => 'restockable', 'created_at' => now(), 'updated_at' => now()],
+            ['sales_order_item_id' => $itemB->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 3, 'return_condition' => 'damaged', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id, $itemB->id]);
+
+        // Started at 10. Restockable adds 2 → 12. Damaged records write-off (deducts from stock) → 9.
+        $this->assertEquals(9, $stock->fresh()->quantity,
+            'Stock: 10 + 2 restockable - 3 damaged write-off = 9');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 3. Double-return prevention
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_approve_throws_when_so_already_sales_returned(): void
+    {
+        $stock = $this->makeStock($this->product, 'DR-001', 400.00, 10);
+        $so    = $this->makeSo('cash', 1000.00, 'sales-returned');
+        $item  = $this->addItem($so, $stock, 1, 1000.00);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('already been returned');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+    }
+
+    public function test_approve_throws_when_so_partially_returned(): void
+    {
+        $stock = $this->makeStock($this->product, 'DR-002', 400.00, 10);
+        $so    = $this->makeSo('cash', 2000.00, 'partially-returned');
+        $item  = $this->addItem($so, $stock, 2, 1000.00, 1);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('already been returned');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4. Return history rows
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_return_history_row_created_for_each_returned_item(): void
+    {
+        $stock  = $this->makeStock($this->product, 'RH-001', 400.00, 10);
+        $so     = $this->makeSo('credit', 4000.00);
+        $itemA  = $this->addItem($so, $stock, 2, 1000.00);
+        $itemB  = $this->addItem($so, $stock, 2, 1000.00);
+        $inv    = $this->makeInvoice($so, 4000, 4000, 0);
+        $rcpt   = $this->makeReceipt($inv, 4000);
+
+        \DB::table('sales_return_items')->insert([
+            ['sales_order_item_id' => $itemA->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 2, 'return_condition' => 'restockable', 'created_at' => now(), 'updated_at' => now()],
+            ['sales_order_item_id' => $itemB->id, 'source_receipt_id' => $rcpt->id,
+             'return_quantity' => 1, 'return_condition' => 'damaged', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id, $itemB->id]);
+
+        $history = SalesReturnHistory::where('sales_order_id', $so->id)->get();
+        $this->assertCount(2, $history, 'One history row per returned item');
+
+        $histA = $history->firstWhere('sales_order_item_id', $itemA->id);
+        $histB = $history->firstWhere('sales_order_item_id', $itemB->id);
+
+        $this->assertEquals(2, $histA->quantity,  'Item A history quantity must be 2');
+        $this->assertEquals(1, $histB->quantity,  'Item B history quantity must be 1');
+        $this->assertEquals('restockable', $histA->condition);
+        $this->assertEquals('damaged',     $histB->condition);
+        $this->assertEquals(2000.00, (float) $histA->total_value);
+        $this->assertEquals(1000.00, (float) $histB->total_value);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 5. Credit full return + replacement > return value (invoice state)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_credit_return_with_extra_replacement_invoice_amounts_are_correct(): void
+    {
+        // Return ₱2,000 worth. Replace with ₱2,500 → extra ₱500.
+        $returnStock = $this->makeStock($this->product,  'FR-001', 400.00, 10);
+        $repStock    = $this->makeStock($this->productB, 'FR-002', 500.00, 10);
+
+        $so      = $this->makeSo('credit', 2000.00);
+        $item    = $this->addItem($so, $returnStock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 2,
+            'price'      => 1250.00, // ₱2,500 total → ₱500 extra
+        ]]);
+
+        $invoice->refresh();
+
+        // The extra ₱500 must be the only charge remaining on the invoice.
+        // After full return: original ₱2,000 is fully returned.
+        // The extra receipt for ₱500 is the new obligation.
+        $this->assertEquals('500.00', $invoice->amount_due,
+            'After full return, amount_due must reflect only the ₱500 extra replacement charge');
+        $this->assertEquals('0.00', $invoice->amount_paid,
+            'No payment has been made toward the extra charge yet');
+        $this->assertEquals('500.00', $invoice->balance_due,
+            'Customer still owes ₱500 for the extra replacement value');
+
+        // Extra receipt exists for ₱500
+        $extra = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('receipt_type', 'payment')
+            ->where('amount_paid', 500.00)
+            ->first();
+        $this->assertNotNull($extra, 'An extra receipt for ₱500 must exist');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 6. Cash full return without replacement — invoice untouched
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_cash_full_return_without_replacement_leaves_invoice_unchanged(): void
+    {
+        $stock   = $this->makeStock($this->product, 'CF-001', 400.00, 10);
+        $so      = $this->makeSo('cash', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $invoice->refresh();
+        // Cash with no replacement: stock is restored, JEs are recorded,
+        // but the invoice itself stays at original values (no cash refund flow).
+        $this->assertEquals('2000.00', $invoice->amount_due,
+            'Cash return without replacement: invoice amount_due unchanged');
+        $this->assertEquals('2000.00', $invoice->amount_paid,
+            'Cash return without replacement: invoice amount_paid unchanged');
+        $this->assertEquals('0.00', $invoice->balance_due,
+            'Cash return without replacement: balance_due still zero');
+
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 7. End-to-end: full return + extra receipt payment → SO stays returned
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_paying_extra_receipt_after_full_return_keeps_so_as_returned(): void
+    {
+        $returnStock = $this->makeStock($this->product,  'E2E-001', 400.00, 10);
+        $repStock    = $this->makeStock($this->productB, 'E2E-002', 500.00, 10);
+
+        $so      = $this->makeSo('credit', 2000.00);
+        $item    = $this->addItem($so, $returnStock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        // Approve return with extra replacement (₱500 extra)
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 2,
+            'price'      => 1250.00,
+        ]]);
+
+        $so->refresh();
+        $this->assertEquals('sales-returned', $so->status->slug,
+            'SO must be sales-returned after full return approval');
+
+        // Now customer pays the extra ₱500 via ReceiptClass::save()
+        $invoice->refresh();
+        $payRequest = new Request();
+        $payRequest->merge([
+            'ar_invoice_id' => $invoice->id,
+            'receipt_date'  => now()->toDateString(),
+            'amount_paid'   => $invoice->balance_due,
+            'payment_mode'  => 'cash',
+        ]);
+
+        app(ReceiptClass::class)->save($payRequest);
+
+        // Critical: SO must remain sales-returned, not become partially-paid or closed
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug,
+            'Paying the extra receipt must not change SO status from sales-returned');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 8. adjustment() eligibility guards
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_adjustment_rejected_for_cancelled_so(): void
+    {
+        $stock = $this->makeStock($this->product, 'AG-001', 400.00, 10);
+        $so    = $this->makeSo('cash', 1000.00, 'cancelled');
+        $item  = $this->addItem($so, $stock, 1, 1000.00);
+        $inv   = $this->makeInvoice($so, 1000, 1000, 0);
+        $rcpt  = $this->makeReceipt($inv, 1000);
+
+        $request = new Request();
+        $request->merge([
+            'id'                => $so->id,
+            'type'              => 'Sales Return',
+            'reason'            => 'test',
+            'receipt_id'        => $rcpt->id,
+            'item_ids'          => [$item->id],
+            'return_quantities' => [$item->id => 1],
+            'return_conditions' => [$item->id => 'restockable'],
+        ]);
+
+        $this->expectException(ValidationException::class);
+        app(SalesOrderClass::class)->adjustment($request);
+    }
+
+    public function test_adjustment_rejected_for_already_returned_so(): void
+    {
+        $stock = $this->makeStock($this->product, 'AG-002', 400.00, 10);
+        $so    = $this->makeSo('cash', 1000.00, 'sales-returned');
+        $item  = $this->addItem($so, $stock, 1, 1000.00);
+        $inv   = $this->makeInvoice($so, 1000, 1000, 0);
+        $rcpt  = $this->makeReceipt($inv, 1000);
+
+        $request = new Request();
+        $request->merge([
+            'id'                => $so->id,
+            'type'              => 'Sales Return',
+            'reason'            => 'test',
+            'receipt_id'        => $rcpt->id,
+            'item_ids'          => [$item->id],
+            'return_quantities' => [$item->id => 1],
+            'return_conditions' => [$item->id => 'restockable'],
+        ]);
+
+        $this->expectException(ValidationException::class);
+        app(SalesOrderClass::class)->adjustment($request);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 9. Revenue reversal JE amount matches refund
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_revenue_reversal_amount_equals_refund_amount(): void
+    {
+        // 3 units @ ₱800 discount ₱50/unit → effective price ₱750/unit
+        // Return 2 units → refund = 2 × 750 = 1500
+        $stock   = $this->makeStock($this->product, 'RR-001', 400.00, 10);
+        $so      = SalesOrder::create([
+            'so_number' => 'SO-RR-001', 'order_date' => now()->toDateString(),
+            'customer_id' => $this->customer->id,
+            'status_id' => ListStatus::where('slug', 'sales-return-approval')->first()->id,
+            'total_amount' => 2250, 'payment_mode' => 'credit', 'added_by_id' => $this->user->id,
+        ]);
+
+        $item = new SalesOrderItem([
+            'product_id' => $this->product->id, 'quantity' => 3, 'price' => 800.00,
+            'price_type' => 'retail', 'batch_code' => $stock->batch_code, 'discount_per_unit' => 50.00,
+        ]);
+        $item->sales_order_id = $so->id;
+        $item->save();
+
+        $invoice = $this->makeInvoice($so, 2250, 2250, 0);
+        $receipt = $this->makeReceipt($invoice, 2250);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $revenueJe = JournalEntry::where('entry_type', 'sales_return_revenue')->first();
+        $this->assertNotNull($revenueJe, 'A sales_return_revenue JE must exist');
+
+        $lines = JournalEntryLine::where('journal_entry_id', $revenueJe->id)->get();
+        $this->assertCount(2, $lines);
+        $this->assertEquals('1500.00', $lines->first()->amount, 'Revenue reversal must equal 2 × (800 - 50) = 1,500');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 10. Replacement items in a CREDIT return — accounting + DB both work
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_credit_partial_return_with_replacement_works_end_to_end(): void
+    {
+        $returnStock = $this->makeStock($this->product,  'CR-001', 400.00, 10);
+        $repStock    = $this->makeStock($this->productB, 'CR-002', 500.00, 10);
+
+        // 3-item SO, return 1 item and replace with replacement product (same value)
+        $so      = $this->makeSo('credit', 3000.00);
+        $itemA   = $this->addItem($so, $returnStock, 1, 1000.00); // returned
+        $itemB   = $this->addItem($so, $returnStock, 2, 1000.00); // kept
+        $invoice = $this->makeInvoice($so, 3000, 3000, 0);
+        $receipt = $this->makeReceipt($invoice, 3000);
+
+        $this->queueReturn($itemA, $receipt, 1, 'restockable');
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 1,
+            'price'      => 1000.00, // equal value → no extra
+        ]]);
+
+        // SO is partially-returned (itemB kept)
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug);
+
+        // Replacement persisted
+        $this->assertCount(1, SalesReturnReplacement::where('sales_order_id', $so->id)->get());
+
+        // Replacement stock deducted
+        $this->assertEquals(9, $repStock->fresh()->quantity, 'Replacement stock: 10 - 1 = 9');
+
+        // Return stock restored
+        $this->assertEquals(11, $returnStock->fresh()->quantity, 'Returned stock: 10 + 1 = 11');
+
+        // Replacement JE created
+        $this->assertNotNull(
+            JournalEntry::where('entry_type', 'replacement_inventory_out')->first(),
+            'replacement_inventory_out JE must exist'
+        );
+
+        // Invoice adjusted correctly (partial credit return): ₱3,000 → ₱2,000
+        $invoice->refresh();
+        $this->assertEquals('2000.00', $invoice->amount_due,   'Invoice amount_due must be ₱2,000 (kept items only)');
+        $this->assertEquals('2000.00', $invoice->amount_paid,  'Invoice amount_paid must be ₱2,000');
+        $this->assertEquals('0.00',    $invoice->balance_due,  'Balance must be zero (already paid for kept items)');
+
+        $this->assertJournalEntriesBalanced();
+    }
+}

--- a/tests/Feature/SalesReturn/ComplexScenariosTest.php
+++ b/tests/Feature/SalesReturn/ComplexScenariosTest.php
@@ -40,7 +40,7 @@ class ComplexScenariosTest extends TestCase
         foreach ([
             'sales-return-approval', 'sales-returned', 'partially-returned',
             'paid', 'cancelled', 'closed', 'for-payment', 'unpaid', 'partially-paid',
-            'pending', 'allowance-applied',
+            'pending', 'allowance-applied', 'liquidated',
         ] as $slug) {
             ListStatus::firstOrCreate(['slug' => $slug], [
                 'name' => ucwords(str_replace('-', ' ', $slug)),
@@ -193,7 +193,7 @@ class ComplexScenariosTest extends TestCase
             'customer_id'  => $this->customer->id,
             'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
             'total_amount' => 4000,
-            'payment_mode' => 'cash',
+            'payment_mode' => 'credit',
             'added_by_id'  => $this->user->id,
         ]);
 
@@ -238,7 +238,7 @@ class ComplexScenariosTest extends TestCase
             'customer_id'  => $this->customer->id,
             'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
             'total_amount' => 6000,
-            'payment_mode' => 'cash',
+            'payment_mode' => 'credit',
             'added_by_id'  => $this->user->id,
         ]);
 
@@ -446,7 +446,7 @@ class ComplexScenariosTest extends TestCase
             'customer_id'  => $this->customer->id,
             'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
             'total_amount' => 2000,
-            'payment_mode' => 'cash',
+            'payment_mode' => 'credit',
             'added_by_id'  => $this->user->id,
         ]);
 
@@ -487,7 +487,7 @@ class ComplexScenariosTest extends TestCase
             'customer_id'  => $this->customer->id,
             'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
             'total_amount' => 4000,
-            'payment_mode' => 'cash',
+            'payment_mode' => 'credit',
             'added_by_id'  => $this->user->id,
         ]);
 

--- a/tests/Feature/SalesReturn/DataRecordingTest.php
+++ b/tests/Feature/SalesReturn/DataRecordingTest.php
@@ -1,0 +1,779 @@
+<?php
+
+namespace Tests\Feature\SalesReturn;
+
+use App\Models\ArInvoice;
+use App\Models\Customer;
+use App\Models\InventoryAdjustment;
+use App\Models\InventoryStocks;
+use App\Models\JournalEntry;
+use App\Models\ListStatus;
+use App\Models\Product;
+use App\Models\Receipt;
+use App\Models\ReceivedItem;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderItem;
+use App\Models\SalesReturnHistory;
+use App\Models\SalesReturnReplacement;
+use App\Models\User;
+use App\Services\Modules\SalesOrderClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verifies that every DB table is correctly populated for every return scenario.
+ * Each test isolates one scenario and asserts every table that should be touched.
+ */
+class DataRecordingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Product $product;
+    private Product $productB;
+    private Customer $customer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        foreach ([
+            'sales-return-approval', 'sales-returned', 'partially-returned',
+            'paid', 'cancelled', 'closed', 'for-payment', 'unpaid',
+            'partially-paid', 'pending', 'liquidated', 'approved',
+        ] as $slug) {
+            ListStatus::firstOrCreate(['slug' => $slug], [
+                'name'       => ucwords(str_replace('-', ' ', $slug)),
+                'text_color' => '#fff',
+                'bg_color'   => '#333',
+            ]);
+        }
+
+        $unitId  = \DB::table('list_units')->insertGetId(['name' => 'Sack', 'created_at' => now(), 'updated_at' => now()]);
+        $brandId = \DB::table('list_brands')->insertGetId(['name' => 'Brand', 'created_at' => now(), 'updated_at' => now()]);
+
+        $this->product  = Product::create(['code' => 'P1-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true]);
+        $this->productB = Product::create(['code' => 'P2-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true]);
+
+        $this->customer = Customer::create([
+            'name' => 'Test Customer', 'address' => 'Addr', 'contact_number' => '09000000001',
+            'added_by_id' => $this->user->id, 'is_active' => true, 'is_regular' => false, 'is_blacklisted' => false,
+        ]);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeStock(Product $product, string $batch, float $cost, int $qty): InventoryStocks
+    {
+        $supId = \DB::table('list_suppliers')->insertGetId([
+            'name' => 'S-' . $batch, 'address' => 'A', 'contact_person' => 'P',
+            'contact_number' => '0', 'email' => 'x@x.com', 'tin' => '0',
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $stId = ListStatus::where('slug', 'paid')->first()->id;
+        $poId = \DB::table('purchase_orders')->insertGetId([
+            'supplier_id' => $supId, 'status_id' => $stId, 'created_by_id' => $this->user->id,
+            'po_date' => now()->toDateString(), 'total_amount' => ($qty + 10) * $cost,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $piId = \DB::table('purchase_order_items')->insertGetId([
+            'po_id' => $poId, 'product_id' => $product->id,
+            'quantity' => $qty + 10, 'unit_cost' => $cost, 'total_cost' => ($qty + 10) * $cost,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $rsId = \DB::table('received_stocks')->insertGetId([
+            'po_id' => $poId, 'supplier_id' => $supId, 'received_date' => now()->toDateString(),
+            'received_no' => 'RS-' . $batch, 'payment_mode' => 'cash', 'amount_paid' => 0,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $ri = ReceivedItem::create([
+            'received_id' => $rsId, 'product_id' => $product->id,
+            'quantity' => $qty + 10, 'unit_cost' => $cost, 'total_cost' => ($qty + 10) * $cost,
+            'po_item_id' => $piId,
+        ]);
+        return InventoryStocks::create([
+            'received_item_id' => $ri->id,
+            'quantity'         => $qty,
+            'retail_price'     => $cost * 1.6,
+            'wholesale_price'  => $cost * 1.5,
+            'batch_code'       => $batch,
+        ]);
+    }
+
+    private function makeSo(string $mode, float $total): SalesOrder
+    {
+        return SalesOrder::create([
+            'so_number'    => 'SO-DR-' . uniqid(),
+            'order_date'   => now()->toDateString(),
+            'customer_id'  => $this->customer->id,
+            'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
+            'total_amount' => $total,
+            'payment_mode' => $mode,
+            'added_by_id'  => $this->user->id,
+        ]);
+    }
+
+    private function addItem(SalesOrder $so, InventoryStocks $stock, int $qty, float $price, int $returnedQty = 0): SalesOrderItem
+    {
+        $item = new SalesOrderItem([
+            'product_id'        => $stock->receivedItem->product_id,
+            'quantity'          => $qty,
+            'returned_quantity' => $returnedQty,
+            'price'             => $price,
+            'price_type'        => 'retail',
+            'batch_code'        => $stock->batch_code,
+            'discount_per_unit' => 0,
+        ]);
+        $item->sales_order_id = $so->id;
+        $item->save();
+        return $item;
+    }
+
+    private function makeInvoice(SalesOrder $so, float $due, float $paid, float $balance, string $slug = 'paid'): ArInvoice
+    {
+        return ArInvoice::create([
+            'sales_order_id' => $so->id,
+            'status_id'      => ListStatus::where('slug', $slug)->first()->id,
+            'invoice_number' => 'INV-' . $so->so_number,
+            'invoice_date'   => now()->toDateString(),
+            'amount_due'     => $due,
+            'amount_paid'    => $paid,
+            'balance_due'    => $balance,
+        ]);
+    }
+
+    private function makeReceipt(ArInvoice $inv, float $amount, string $slug = 'paid'): Receipt
+    {
+        return Receipt::create([
+            'ar_invoice_id'  => $inv->id,
+            'customer_id'    => $this->customer->id,
+            'status_id'      => ListStatus::where('slug', $slug)->first()->id,
+            'receipt_number' => 'REC-' . uniqid(),
+            'receipt_type'   => 'payment',
+            'receipt_date'   => now()->toDateString(),
+            'amount_paid'    => $amount,
+            'payment_mode'   => 'cash',
+        ]);
+    }
+
+    private function queueReturn(SalesOrderItem $item, Receipt $receipt, int $qty, string $condition = 'restockable'): void
+    {
+        \DB::table('sales_return_items')->insert([
+            'sales_order_item_id' => $item->id,
+            'source_receipt_id'   => $receipt->id,
+            'return_quantity'     => $qty,
+            'return_condition'    => $condition,
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ]);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 1. Full cash return — restockable, no replacement
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_cash_return_records_all_tables(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-001', 400.00, 10);
+        $so      = $this->makeSo('cash', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        $stockBefore = $stock->fresh()->quantity; // 10
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        // SO status
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug);
+
+        // sales_order_items.returned_quantity incremented
+        $this->assertEquals(2, $item->fresh()->returned_quantity);
+
+        // sales_return_history — 1 row with correct values
+        $this->assertDatabaseCount('sales_return_history', 1);
+        $history = SalesReturnHistory::first();
+        $this->assertEquals($item->id, $history->sales_order_item_id);
+        $this->assertEquals($this->product->id, $history->product_id);
+        $this->assertEquals(2, $history->quantity);
+        $this->assertEquals('restockable', $history->condition);
+        $this->assertEquals(1000.00, (float) $history->unit_price);
+        $this->assertEquals(2000.00, (float) $history->total_value);
+        $this->assertEquals($this->user->id, $history->approved_by_id);
+
+        // inventory_adjustments — restockable returns ADD stock (type=1)
+        $adj = InventoryAdjustment::where('inventory_stocks_id', $stock->id)
+            ->orderByDesc('id')->first();
+        $this->assertNotNull($adj);
+        $this->assertEquals(1, $adj->type);
+        $this->assertEquals($stockBefore + 2, (int) $adj->new_quantity);
+        $this->assertEquals($stockBefore, (int) $adj->previous_quantity);
+
+        // journal_entries — sales_return_revenue and sales_return_inventory
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_revenue']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_inventory']);
+        $this->assertDatabaseMissing('journal_entries', ['entry_type' => 'sales_return_damage_writeoff']);
+        $this->assertDatabaseMissing('journal_entries', ['entry_type' => 'replacement_inventory_out']);
+
+        // no replacement records
+        $this->assertDatabaseCount('sales_return_replacements', 0);
+
+        // cash path: invoice amounts unchanged (no credit adjustment)
+        $invoice->refresh();
+        $this->assertEquals(2000.00, (float) $invoice->amount_due);
+        $this->assertEquals(2000.00, (float) $invoice->amount_paid);
+
+        // source receipt still has the audit note
+        $receipt->refresh();
+        $this->assertNotNull($receipt->notes);
+        $this->assertStringContainsString('Return adjustment', $receipt->notes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 2. Full cash return — damaged item
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_cash_return_damaged_records_damage_adjustment_and_writeoff_je(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-002', 400.00, 10);
+        $so      = $this->makeSo('cash', 1000.00);
+        $item    = $this->addItem($so, $stock, 1, 1000.00);
+        $invoice = $this->makeInvoice($so, 1000, 1000, 0);
+        $receipt = $this->makeReceipt($invoice, 1000);
+
+        $this->queueReturn($item, $receipt, 1, 'damaged');
+
+        $stockBefore = $stock->fresh()->quantity;
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        // sales_return_history — condition = damaged
+        $history = SalesReturnHistory::first();
+        $this->assertNotNull($history);
+        $this->assertEquals('damaged', $history->condition);
+
+        // inventory_adjustments — damaged uses recordLossOrDamage which stores 'damage' type
+        $adj = InventoryAdjustment::where('inventory_stocks_id', $stock->id)
+            ->orderByDesc('id')->first();
+        $this->assertNotNull($adj);
+        $this->assertEquals('damage', $adj->type);
+        $this->assertEquals($stockBefore - 1, (int) $adj->new_quantity);
+
+        // journal_entries — damage writeoff, NOT sales_return_inventory
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_revenue']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_damage_writeoff']);
+        $this->assertDatabaseMissing('journal_entries', ['entry_type' => 'sales_return_inventory']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 3. Full cash return — replacement equal to return value (no extra receipt)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_cash_return_with_equal_replacement_records_replacement_tables(): void
+    {
+        $stock    = $this->makeStock($this->product,  'DR-003', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'DR-004', 500.00, 10);
+        $so       = $this->makeSo('cash', 2000.00);
+        $item     = $this->addItem($so, $stock, 2, 1000.00);   // return value = ₱2,000
+        $invoice  = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt  = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 2,
+            'price'      => 1000.00,  // exactly ₱2,000 = return value
+        ]]);
+
+        // sales_return_replacements — 1 row
+        $this->assertDatabaseCount('sales_return_replacements', 1);
+        $rep = SalesReturnReplacement::first();
+        $this->assertEquals($this->productB->id, $rep->product_id);
+        $this->assertEquals(2, $rep->quantity);
+        $this->assertEquals(1000.00, (float) $rep->price);
+        $this->assertEquals(2000.00, (float) $rep->total_value);
+        $this->assertEquals($this->user->id, $rep->replaced_by_id);
+
+        // inventory_adjustments — 2 rows: +2 for return (restockable), -2 for replacement
+        $addAdj = InventoryAdjustment::where('inventory_stocks_id', $stock->id)->first();
+        $this->assertNotNull($addAdj);
+        $this->assertEquals(1, $addAdj->type); // addition
+
+        $deductAdj = InventoryAdjustment::where('inventory_stocks_id', $repStock->id)->first();
+        $this->assertNotNull($deductAdj);
+        $this->assertEquals(2, $deductAdj->type); // subtraction (deductStock type=2)
+
+        // journal_entries — replacement_inventory_out but NO extra receipt JE
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'replacement_inventory_out']);
+
+        // No extra receipt created (equal value)
+        $extraReceipts = Receipt::where('receipt_type', 'payment')
+            ->where('ar_invoice_id', $invoice->id)
+            ->where('id', '!=', $receipt->id)
+            ->get();
+        $this->assertCount(0, $extraReceipts, 'No extra receipt should be created when replacement equals return value');
+
+        // Source receipt notes contain replacement info
+        $receipt->refresh();
+        $this->assertStringContainsString('Replaced with:', $receipt->notes);
+        $this->assertStringNotContainsString('Extra charged:', $receipt->notes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4. Full cash return — replacement exceeds return value (extra receipt)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_cash_return_with_excess_replacement_creates_extra_receipt_and_je(): void
+    {
+        $stock    = $this->makeStock($this->product,  'DR-005', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'DR-006', 500.00, 10);
+        $so       = $this->makeSo('cash', 2000.00);
+        $item     = $this->addItem($so, $stock, 2, 1000.00);   // return value = ₱2,000
+        $invoice  = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt  = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 3,
+            'price'      => 1000.00,  // ₱3,000 replacement > ₱2,000 return → extra ₱1,000
+        ]]);
+
+        // Extra receipt created with the ₱1,000 difference
+        $extraReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('id', '!=', $receipt->id)
+            ->get();
+        $this->assertCount(1, $extraReceipts);
+        $extra = $extraReceipts->first();
+        $this->assertEquals(1000.00, (float) $extra->amount_paid);
+
+        // Invoice updated with extra amount
+        $invoice->refresh();
+        $this->assertEquals(3000.00, (float) $invoice->amount_due);
+
+        // journal_entries — receipt_collection entry for extra receipt
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'replacement_inventory_out']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'receipt_collection']);
+
+        // Source receipt notes contain extra charge reference
+        $receipt->refresh();
+        $this->assertStringContainsString('Extra charged', $receipt->notes);
+        $this->assertStringContainsString($extra->receipt_number, $receipt->notes);
+
+        // Extra receipt notes contain cross-reference back to source receipt
+        $extra->refresh();
+        $this->assertNotNull($extra->notes);
+        $this->assertStringContainsString($receipt->receipt_number, $extra->notes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 5. Full credit return — no replacement
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_credit_return_cancels_invoice_and_receipt_and_creates_refund(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-007', 400.00, 10);
+        $so      = $this->makeSo('credit', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        // SO status
+        $this->assertEquals('sales-returned', $so->fresh()->status->slug);
+
+        // sales_return_history recorded
+        $this->assertDatabaseCount('sales_return_history', 1);
+
+        // Invoice cancelled, amounts zeroed
+        $invoice->refresh();
+        $this->assertEquals('cancelled', $invoice->status->slug);
+        $this->assertEquals(0.00, (float) $invoice->amount_due);
+        $this->assertEquals(0.00, (float) $invoice->amount_paid);
+        $this->assertEquals(0.00, (float) $invoice->balance_due);
+
+        // Source receipt cancelled
+        $receipt->refresh();
+        $this->assertEquals('cancelled', $receipt->status->slug);
+
+        // Refund receipt created
+        $refundReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('receipt_type', 'refund')
+            ->get();
+        $this->assertCount(1, $refundReceipts);
+        $refund = $refundReceipts->first();
+        $this->assertEquals(2000.00, (float) $refund->amount_paid);
+
+        // journal_entries — sales_return_revenue + sales_return_inventory
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_revenue']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_inventory']);
+
+        // Source receipt notes recorded
+        $receipt->refresh();
+        $this->assertNotNull($receipt->notes);
+        $this->assertStringContainsString('Return adjustment', $receipt->notes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 6. Full credit return with replacement exceeding return value
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_credit_return_with_excess_replacement_resets_invoice_to_extra_only(): void
+    {
+        $stock    = $this->makeStock($this->product,  'DR-008', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'DR-009', 500.00, 10);
+        $so       = $this->makeSo('credit', 2000.00);
+        $item     = $this->addItem($so, $stock, 2, 1000.00);   // return value = ₱2,000
+        $invoice  = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt  = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 1,
+            'price'      => 2500.00,  // ₱2,500 > ₱2,000 return → extra ₱500
+        ]]);
+
+        // Invoice reset to 0, then extra charge added: amount_due = ₱500
+        $invoice->refresh();
+        $this->assertEquals(500.00, (float) $invoice->amount_due);
+        $this->assertEquals(500.00, (float) $invoice->balance_due);
+
+        // sales_return_replacements — 1 row
+        $this->assertDatabaseCount('sales_return_replacements', 1);
+        $rep = SalesReturnReplacement::first();
+        $this->assertEquals($this->productB->id, $rep->product_id);
+        $this->assertEquals(2500.00, (float) $rep->price);
+
+        // Extra receipt with correct amount
+        $extraReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('id', '!=', $receipt->id)
+            ->whereNotIn('receipt_type', ['refund'])
+            ->get();
+        $this->assertCount(1, $extraReceipts);
+        $this->assertEquals(500.00, (float) $extraReceipts->first()->amount_paid);
+
+        // Refund receipt also created (credit path)
+        $this->assertDatabaseHas('receipts', ['receipt_type' => 'refund']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 7. Partial cash return — only some items returned
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_partial_cash_return_only_increments_returned_items(): void
+    {
+        $stock  = $this->makeStock($this->product, 'DR-010', 400.00, 10);
+        $so     = $this->makeSo('cash', 4000.00);
+        $itemA  = $this->addItem($so, $stock, 2, 1000.00);  // returned
+        $itemB  = $this->addItem($so, $stock, 2, 1000.00);  // NOT returned
+        $invoice = $this->makeInvoice($so, 4000, 4000, 0);
+        $receipt = $this->makeReceipt($invoice, 4000);
+
+        // Only queue itemA for return
+        $this->queueReturn($itemA, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id]);
+
+        // SO status is partially-returned
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug);
+
+        // returned_quantity: itemA incremented, itemB unchanged
+        $this->assertEquals(2, $itemA->fresh()->returned_quantity);
+        $this->assertEquals(0, $itemB->fresh()->returned_quantity);
+
+        // sales_return_history — only for itemA
+        $this->assertDatabaseCount('sales_return_history', 1);
+        $history = SalesReturnHistory::first();
+        $this->assertEquals($itemA->id, $history->sales_order_item_id);
+        $this->assertEquals(2, $history->quantity);
+
+        // inventory_adjustments — only 1 stock restoration (for itemA product only)
+        $addedAdj = InventoryAdjustment::where('type', 1)->get();
+        $this->assertCount(1, $addedAdj);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 8. Partial credit return — source cancelled, refund + updated receipts created
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_partial_credit_return_records_invoice_and_receipt_correctly(): void
+    {
+        $stock   = $this->makeStack($this->product, 'DR-011', 400.00, 10);
+        $so      = $this->makeSo('credit', 4000.00);
+        $itemA   = $this->addItem($so, $stock, 2, 1000.00);  // returned (₱2,000)
+        $itemB   = $this->addItem($so, $stock, 2, 1000.00);  // kept
+        $invoice = $this->makeInvoice($so, 4000, 4000, 0);
+        $receipt = $this->makeReceipt($invoice, 4000);
+
+        $this->queueReturn($itemA, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id]);
+
+        // SO status partially-returned
+        $this->assertEquals('partially-returned', $so->fresh()->status->slug);
+
+        // Invoice amount_due and amount_paid reduced by ₱2,000 refund
+        $invoice->refresh();
+        $this->assertEquals(2000.00, (float) $invoice->amount_due);
+        $this->assertEquals(2000.00, (float) $invoice->amount_paid);
+        $this->assertEquals(0.00, (float) $invoice->balance_due);
+
+        // Source receipt cancelled
+        $receipt->refresh();
+        $this->assertEquals('cancelled', $receipt->status->slug);
+
+        // Refund receipt created (₱2,000)
+        $refundReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('receipt_type', 'refund')
+            ->get();
+        $this->assertCount(1, $refundReceipts);
+        $this->assertEquals(2000.00, (float) $refundReceipts->first()->amount_paid);
+
+        // Updated receipt created (₱2,000 — remaining balance)
+        $updatedReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('receipt_type', 'updated')
+            ->get();
+        $this->assertCount(1, $updatedReceipts);
+        $this->assertEquals(2000.00, (float) $updatedReceipts->first()->amount_paid);
+
+        // Source receipt notes
+        $receipt->refresh();
+        $this->assertStringContainsString('Return adjustment', $receipt->notes);
+
+        // journal_entries created for return
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_revenue']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_inventory']);
+        // journal entry for the updated receipt
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'receipt_collection']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 9. Partial credit return with replacement (> refund) — extra receipt + updated receipt
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_partial_credit_return_with_excess_replacement_creates_both_receipts(): void
+    {
+        $stock    = $this->makeStock($this->product,  'DR-012', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'DR-013', 500.00, 10);
+        $so       = $this->makeSo('credit', 4000.00);
+        $itemA    = $this->addItem($so, $stock, 2, 1000.00);  // returned (₱2,000)
+        $itemB    = $this->addItem($so, $stock, 2, 1000.00);  // kept
+        $invoice  = $this->makeInvoice($so, 4000, 4000, 0);
+        $receipt  = $this->makeReceipt($invoice, 4000);
+
+        $this->queueReturn($itemA, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 3,
+            'price'      => 1000.00,  // ₱3,000 replacement > ₱2,000 return → extra ₱1,000
+        ]]);
+
+        // sales_return_replacements — 1 row
+        $this->assertDatabaseCount('sales_return_replacements', 1);
+
+        // Refund receipt created
+        $this->assertDatabaseHas('receipts', ['receipt_type' => 'refund']);
+
+        // Updated receipt created
+        $this->assertDatabaseHas('receipts', ['receipt_type' => 'updated']);
+
+        // Extra receipt for the ₱1,000 difference
+        $nonRefundReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('id', '!=', $receipt->id)
+            ->whereNotIn('receipt_type', ['refund', 'updated'])
+            ->get();
+        $this->assertCount(1, $nonRefundReceipts);
+        $this->assertEquals(1000.00, (float) $nonRefundReceipts->first()->amount_paid);
+
+        // invoice: original ₱4,000 - ₱2,000 refund + ₱1,000 replacement extra = ₱3,000 due
+        $invoice->refresh();
+        $this->assertEquals(3000.00, (float) $invoice->amount_due);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 10. sales_return_items cleaned up after approval
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_sales_return_items_are_deleted_after_approval(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-014', 400.00, 10);
+        $so      = $this->makeSo('cash', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        $this->assertDatabaseCount('sales_return_items', 1);
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $this->assertDatabaseCount('sales_return_items', 0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 11. approved_by_id set on SO after return approval
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_approved_by_id_is_set_on_so_after_return_approval(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-015', 400.00, 10);
+        $so      = $this->makeSo('cash', 1000.00);
+        $item    = $this->addItem($so, $stock, 1, 1000.00);
+        $invoice = $this->makeInvoice($so, 1000, 1000, 0);
+        $receipt = $this->makeReceipt($invoice, 1000);
+
+        $this->queueReturn($item, $receipt, 1, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $so->refresh();
+        $this->assertEquals($this->user->id, $so->approved_by_id);
+        $this->assertNotNull($so->approved_at);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 12. journal_entry_lines balance for each scenario
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_all_journal_entries_are_balanced_after_full_cash_return_with_replacement(): void
+    {
+        $stock    = $this->makeStock($this->product,  'DR-016', 400.00, 10);
+        $repStock = $this->makeStock($this->productB, 'DR-017', 500.00, 10);
+        $so       = $this->makeSo('cash', 2000.00);
+        $item     = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice  = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt  = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], [[
+            'product_id' => $this->productB->id,
+            'quantity'   => 3,
+            'price'      => 1000.00,  // ₱3,000 replacement → extra ₱1,000
+        ]]);
+
+        $entries = JournalEntry::with('lines')->get();
+        foreach ($entries as $entry) {
+            $debit  = $entry->lines->where('line_type', 'debit')->sum('amount');
+            $credit = $entry->lines->where('line_type', 'credit')->sum('amount');
+            $this->assertEquals(
+                round($debit, 2),
+                round($credit, 2),
+                "Journal entry #{$entry->id} (type: {$entry->entry_type}) is unbalanced: debit={$debit}, credit={$credit}"
+            );
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 13. Mixed conditions — restockable + damaged in same return
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_mixed_return_conditions_record_separate_adjustments_and_entries(): void
+    {
+        $stock  = $this->makeStock($this->product, 'DR-018', 400.00, 10);
+        $so     = $this->makeSo('cash', 4000.00);
+        $itemA  = $this->addItem($so, $stock, 2, 1000.00);  // restockable
+        $itemB  = $this->addItem($so, $stock, 2, 1000.00);  // damaged
+        $invoice = $this->makeInvoice($so, 4000, 4000, 0);
+        $receipt = $this->makeReceipt($invoice, 4000);
+
+        $this->queueReturn($itemA, $receipt, 2, 'restockable');
+        $this->queueReturn($itemB, $receipt, 2, 'damaged');
+
+        app(SalesOrderClass::class)->approve($so->id, [$itemA->id, $itemB->id]);
+
+        // 2 history rows — one per item
+        $this->assertDatabaseCount('sales_return_history', 2);
+        $conditions = SalesReturnHistory::pluck('condition')->toArray();
+        $this->assertContains('restockable', $conditions);
+        $this->assertContains('damaged', $conditions);
+
+        // inventory_adjustments — type=1 (addition) for restockable, type='damage' for damaged
+        $addAdj    = InventoryAdjustment::where('type', 1)->first();
+        $damageAdj = InventoryAdjustment::where('type', 'damage')->first();
+        $this->assertNotNull($addAdj,    'Restockable return must create type=1 inventory adjustment');
+        $this->assertNotNull($damageAdj, 'Damaged return must create type=damage inventory adjustment');
+
+        // journal_entries — both inventory and damage writeoff
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_revenue']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_inventory']);
+        $this->assertDatabaseHas('journal_entries', ['entry_type' => 'sales_return_damage_writeoff']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 14. Partial return quantity — only returned qty incremented (not full qty)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_partial_quantity_return_increments_only_requested_quantity(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-019', 400.00, 10);
+        $so      = $this->makeSo('cash', 5000.00);
+        $item    = $this->addItem($so, $stock, 5, 1000.00);  // 5 units ordered
+        $invoice = $this->makeInvoice($so, 5000, 5000, 0);
+        $receipt = $this->makeReceipt($invoice, 5000);
+
+        // Only return 3 of the 5 units
+        $this->queueReturn($item, $receipt, 3, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        // Partially returned — only 3 units
+        $this->assertEquals(3, $item->fresh()->returned_quantity);
+
+        // History records 3 units returned
+        $history = SalesReturnHistory::first();
+        $this->assertNotNull($history);
+        $this->assertEquals(3, $history->quantity);
+        $this->assertEquals(3000.00, (float) $history->total_value); // 3 × ₱1,000
+
+        // Inventory adjustment adds 3 units back
+        $adj = InventoryAdjustment::where('type', 1)->first();
+        $this->assertNotNull($adj);
+        $this->assertEquals(3, $adj->new_quantity - $adj->previous_quantity);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 15. No replacement — sales_return_replacements stays empty
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_return_without_replacement_leaves_replacement_table_empty(): void
+    {
+        $stock   = $this->makeStock($this->product, 'DR-020', 400.00, 10);
+        $so      = $this->makeSo('cash', 2000.00);
+        $item    = $this->addItem($so, $stock, 2, 1000.00);
+        $invoice = $this->makeInvoice($so, 2000, 2000, 0);
+        $receipt = $this->makeReceipt($invoice, 2000);
+
+        $this->queueReturn($item, $receipt, 2, 'restockable');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id]);
+
+        $this->assertDatabaseCount('sales_return_replacements', 0);
+        $this->assertDatabaseMissing('journal_entries', ['entry_type' => 'replacement_inventory_out']);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private helper (typo fix — makeStack → makeStock alias)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeStack(Product $product, string $batch, float $cost, int $qty): InventoryStocks
+    {
+        return $this->makeStock($product, $batch, $cost, $qty);
+    }
+}

--- a/tests/Feature/SalesReturn/ReplacementItemsTest.php
+++ b/tests/Feature/SalesReturn/ReplacementItemsTest.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Tests\Feature\SalesReturn;
+
+use App\Models\Account;
+use App\Models\ArInvoice;
+use App\Models\Customer;
+use App\Models\InventoryStocks;
+use App\Models\JournalEntry;
+use App\Models\JournalEntryLine;
+use App\Models\ListStatus;
+use App\Models\Product;
+use App\Models\Receipt;
+use App\Models\ReceivedItem;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderItem;
+use App\Models\SalesReturnReplacement;
+use App\Models\User;
+use App\Services\Modules\SalesOrderClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class ReplacementItemsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Product $returnProduct;
+    private Product $replacementProduct;
+    private Customer $customer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+
+        foreach ([
+            'sales-return-approval', 'sales-returned', 'partially-returned',
+            'paid', 'cancelled', 'closed', 'for-payment', 'unpaid', 'partially-paid', 'pending',
+        ] as $slug) {
+            ListStatus::firstOrCreate(['slug' => $slug], [
+                'name'        => ucwords(str_replace('-', ' ', $slug)),
+                'text_color'  => '#fff',
+                'bg_color'    => '#333',
+            ]);
+        }
+
+        $unitId  = \DB::table('list_units')->insertGetId(['name' => 'Sack', 'created_at' => now(), 'updated_at' => now()]);
+        $brandId = \DB::table('list_brands')->insertGetId(['name' => 'Brand', 'created_at' => now(), 'updated_at' => now()]);
+
+        $this->returnProduct = Product::create([
+            'code' => 'RETURN-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true,
+        ]);
+        $this->replacementProduct = Product::create([
+            'code' => 'REPLACE-' . uniqid(), 'weight' => 50, 'unit_id' => $unitId, 'brand_id' => $brandId, 'is_active' => true,
+        ]);
+
+        $this->customer = Customer::create([
+            'name'           => 'Test Customer',
+            'address'        => 'Test Address',
+            'contact_number' => '09000000001',
+            'added_by_id'    => $this->user->id,
+            'is_active'      => true,
+            'is_regular'     => false,
+            'is_blacklisted' => false,
+        ]);
+    }
+
+    private function makeStock(Product $product, string $batchCode, float $unitCost, int $qty): InventoryStocks
+    {
+        $supplierId = \DB::table('list_suppliers')->insertGetId([
+            'name'           => 'Supplier-' . $batchCode,
+            'address'        => 'Addr',
+            'contact_person' => 'Person',
+            'contact_number' => '09000000000',
+            'email'          => 'x@test.com',
+            'tin'            => '000-000-000',
+            'created_at'     => now(),
+            'updated_at'     => now(),
+        ]);
+
+        $statusId = ListStatus::where('slug', 'paid')->first()->id;
+
+        $poId = \DB::table('purchase_orders')->insertGetId([
+            'supplier_id'   => $supplierId,
+            'status_id'     => $statusId,
+            'created_by_id' => $this->user->id,
+            'po_date'       => now()->toDateString(),
+            'total_amount'  => ($qty + 10) * $unitCost,
+            'created_at'    => now(),
+            'updated_at'    => now(),
+        ]);
+
+        $poItemId = \DB::table('purchase_order_items')->insertGetId([
+            'po_id'      => $poId,
+            'product_id' => $product->id,
+            'quantity'   => $qty + 10,
+            'unit_cost'  => $unitCost,
+            'total_cost' => ($qty + 10) * $unitCost,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $rsId = \DB::table('received_stocks')->insertGetId([
+            'po_id'         => $poId,
+            'supplier_id'   => $supplierId,
+            'received_date' => now()->toDateString(),
+            'received_no'   => 'RS-' . $batchCode,
+            'payment_mode'  => 'cash',
+            'amount_paid'   => 0,
+            'created_at'    => now(),
+            'updated_at'    => now(),
+        ]);
+
+        $ri = ReceivedItem::create([
+            'received_id' => $rsId,
+            'product_id'  => $product->id,
+            'quantity'    => $qty + 10,
+            'unit_cost'   => $unitCost,
+            'total_cost'  => ($qty + 10) * $unitCost,
+            'po_item_id'  => $poItemId,
+        ]);
+
+        return InventoryStocks::create([
+            'received_item_id' => $ri->id,
+            'quantity'         => $qty,
+            'retail_price'     => $unitCost * 1.6,
+            'wholesale_price'  => $unitCost * 1.5,
+            'batch_code'       => $batchCode,
+        ]);
+    }
+
+    private function makeCashSoWithReturn(InventoryStocks $stock, int $qty, float $price): array
+    {
+        $so = SalesOrder::create([
+            'so_number'    => 'SO-REP-' . uniqid(),
+            'order_date'   => now()->toDateString(),
+            'customer_id'  => $this->customer->id,
+            'status_id'    => ListStatus::where('slug', 'sales-return-approval')->first()->id,
+            'total_amount' => $qty * $price,
+            'payment_mode' => 'cash',
+            'added_by_id'  => $this->user->id,
+        ]);
+
+        $item = new SalesOrderItem([
+            'product_id'        => $this->returnProduct->id,
+            'quantity'          => $qty,
+            'price'             => $price,
+            'price_type'        => 'retail',
+            'batch_code'        => $stock->batch_code,
+            'discount_per_unit' => 0,
+        ]);
+        $item->sales_order_id = $so->id;
+        $item->save();
+
+        $invoice = ArInvoice::create([
+            'sales_order_id' => $so->id,
+            'status_id'      => ListStatus::where('slug', 'paid')->first()->id,
+            'invoice_number' => 'INV-' . $so->so_number,
+            'invoice_date'   => now()->toDateString(),
+            'amount_due'     => $qty * $price,
+            'amount_paid'    => $qty * $price,
+            'balance_due'    => 0,
+        ]);
+
+        $receipt = Receipt::create([
+            'ar_invoice_id'  => $invoice->id,
+            'customer_id'    => $this->customer->id,
+            'status_id'      => ListStatus::where('slug', 'paid')->first()->id,
+            'receipt_number' => 'REC-' . $so->so_number,
+            'receipt_type'   => 'payment',
+            'receipt_date'   => now()->toDateString(),
+            'amount_paid'    => $qty * $price,
+            'payment_mode'   => 'cash',
+        ]);
+
+        \DB::table('sales_return_items')->insert([
+            'sales_order_item_id' => $item->id,
+            'source_receipt_id'   => $receipt->id,
+            'return_quantity'     => $qty,
+            'return_condition'    => 'restockable',
+            'created_at'          => now(),
+            'updated_at'          => now(),
+        ]);
+
+        return [$so, $item, $receipt];
+    }
+
+    // ─── 1. replacement_inventory_out journal entry ───────────────────────────
+
+    public function test_replacement_items_create_inventory_out_journal_entry(): void
+    {
+        // Return: 2 units @ ₱1,000 = ₱2,000 return value
+        // Replace: 2 units of replacementProduct @ ₱500 cost, ₱1,000 selling price (equal value, no extra)
+        $returnStock      = $this->makeStock($this->returnProduct, 'BATCH-RET-001', 500.00, 5);
+        $replacementStock = $this->makeStock($this->replacementProduct, 'BATCH-REP-001', 500.00, 5);
+
+        [$so, $item] = $this->makeCashSoWithReturn($returnStock, 2, 1000.00);
+
+        $replacementItems = [[
+            'product_id' => $this->replacementProduct->id,
+            'quantity'   => 2,
+            'price'      => 1000.00, // selling price — equal to return value
+        ]];
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], $replacementItems);
+
+        $je = JournalEntry::where('entry_type', 'replacement_inventory_out')->first();
+        $this->assertNotNull($je, 'A replacement_inventory_out journal entry must be created');
+
+        $lines  = JournalEntryLine::where('journal_entry_id', $je->id)->get();
+        $this->assertCount(2, $lines);
+
+        $debit  = $lines->firstWhere('line_type', 'debit');
+        $credit = $lines->firstWhere('line_type', 'credit');
+
+        $this->assertEquals('cost_of_goods_sold',
+            Account::find($debit->account_id)->slug,
+            'Debit must post to COGS');
+
+        $this->assertEquals('rice_inventory',
+            Account::find($credit->account_id)->slug,
+            'Credit must reduce Rice Inventory');
+
+        // 2 units × ₱500 unit cost = ₱1,000
+        $this->assertEquals('1000.00', $debit->amount,  'COGS debit must be ₱1,000');
+        $this->assertEquals('1000.00', $credit->amount, 'Inventory credit must be ₱1,000');
+    }
+
+    // ─── 2. Replacement records persisted to sales_return_replacements ────────
+
+    public function test_replacement_items_are_persisted_to_database(): void
+    {
+        $returnStock      = $this->makeStock($this->returnProduct, 'BATCH-RET-002', 400.00, 5);
+        $replacementStock = $this->makeStock($this->replacementProduct, 'BATCH-REP-002', 400.00, 5);
+
+        [$so, $item] = $this->makeCashSoWithReturn($returnStock, 2, 800.00);
+
+        $replacementItems = [[
+            'product_id' => $this->replacementProduct->id,
+            'quantity'   => 2,
+            'price'      => 800.00,
+        ]];
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], $replacementItems);
+
+        $records = SalesReturnReplacement::where('sales_order_id', $so->id)->get();
+        $this->assertCount(1, $records, 'One replacement record must be persisted');
+
+        $rec = $records->first();
+        $this->assertEquals($this->replacementProduct->id, $rec->product_id);
+        $this->assertEquals(2,      $rec->quantity);
+        $this->assertEquals(800.00, (float) $rec->price);
+        $this->assertEquals(1600.00,(float) $rec->total_value);
+        $this->assertNotNull($rec->replaced_at);
+        $this->assertEquals($this->user->id, $rec->replaced_by_id);
+    }
+
+    // ─── 3. Replacement stock is deducted from inventory ─────────────────────
+
+    public function test_replacement_stock_is_deducted_from_inventory(): void
+    {
+        $returnStock      = $this->makeStock($this->returnProduct, 'BATCH-RET-003', 400.00, 5);
+        $replacementStock = $this->makeStock($this->replacementProduct, 'BATCH-REP-003', 400.00, 10);
+
+        [$so, $item] = $this->makeCashSoWithReturn($returnStock, 2, 800.00);
+
+        $replacementItems = [[
+            'product_id' => $this->replacementProduct->id,
+            'quantity'   => 3,
+            'price'      => 800.00,
+        ]];
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], $replacementItems);
+
+        // 10 replacement units - 3 issued = 7
+        $this->assertEquals(7, $replacementStock->fresh()->quantity,
+            'Replacement stock must be deducted by 3 (10 → 7)');
+    }
+
+    // ─── 4. Undervalue replacement is rejected ────────────────────────────────
+
+    public function test_undervalue_replacement_is_rejected(): void
+    {
+        $returnStock      = $this->makeStock($this->returnProduct, 'BATCH-RET-004', 400.00, 5);
+        $replacementStock = $this->makeStock($this->replacementProduct, 'BATCH-REP-004', 400.00, 5);
+
+        [$so, $item] = $this->makeCashSoWithReturn($returnStock, 2, 1000.00); // return value = ₱2,000
+
+        // Replacement total = ₱1,500 — less than ₱2,000 return value
+        $replacementItems = [[
+            'product_id' => $this->replacementProduct->id,
+            'quantity'   => 2,
+            'price'      => 750.00,
+        ]];
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('must be equal to or greater than the return value');
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], $replacementItems);
+    }
+
+    // ─── 5. Extra receipt + JE when replacement > return value ───────────────
+
+    public function test_extra_receipt_and_journal_entry_created_when_replacement_exceeds_return_value(): void
+    {
+        $returnStock      = $this->makeStock($this->returnProduct, 'BATCH-RET-005', 400.00, 5);
+        $replacementStock = $this->makeStock($this->replacementProduct, 'BATCH-REP-005', 400.00, 5);
+
+        // Return value = 2 × ₱1,000 = ₱2,000
+        [$so, $item, $sourceReceipt] = $this->makeCashSoWithReturn($returnStock, 2, 1000.00);
+
+        // Replacement = 2 × ₱1,500 = ₱3,000 → ₱1,000 extra
+        $replacementItems = [[
+            'product_id' => $this->replacementProduct->id,
+            'quantity'   => 2,
+            'price'      => 1500.00,
+        ]];
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], $replacementItems);
+
+        $invoice = ArInvoice::where('sales_order_id', $so->id)->first();
+
+        // Extra receipt for ₱1,000 difference must exist
+        $extraReceipts = Receipt::where('ar_invoice_id', $invoice->id)
+            ->where('receipt_type', 'payment')
+            ->where('amount_paid', 1000.00)
+            ->get();
+        $this->assertCount(1, $extraReceipts, 'An extra receipt for ₱1,000 must be created');
+
+        // A receipt_collection journal entry must exist for the extra receipt
+        $je = JournalEntry::where('entry_type', 'receipt_collection')
+            ->where('source_type', Receipt::class)
+            ->where('source_id', $extraReceipts->first()->id)
+            ->first();
+        $this->assertNotNull($je, 'A receipt_collection JE must exist for the extra receipt');
+
+        // And the replacement_inventory_out JE must also exist
+        $this->assertNotNull(
+            JournalEntry::where('entry_type', 'replacement_inventory_out')->first(),
+            'replacement_inventory_out JE must exist alongside the extra-charge JE'
+        );
+    }
+
+    // ─── 6. No replacement JE when no replacement items provided ─────────────
+
+    public function test_no_replacement_journal_entry_when_no_replacement_items(): void
+    {
+        $returnStock = $this->makeStock($this->returnProduct, 'BATCH-RET-006', 400.00, 5);
+        [$so, $item] = $this->makeCashSoWithReturn($returnStock, 2, 800.00);
+
+        app(SalesOrderClass::class)->approve($so->id, [$item->id], []);
+
+        $this->assertNull(
+            JournalEntry::where('entry_type', 'replacement_inventory_out')->first(),
+            'No replacement JE should exist when no replacement items are provided'
+        );
+    }
+}


### PR DESCRIPTION
…fixes

- Added accounting journal entries for replacement items issued during returns (COGS debit / Inventory credit via new recordReplacementEntries method)
- Fixed ReceiptClass overwriting sales-returned and partially-returned SO status on receipt save/update; fully-returned SOs are now fully protected
- Fixed credit partial return not reducing amount_paid on AR invoice (only amount_due was previously reduced, leaving an overpayment on record)
- Fixed full credit return inflating invoice when replacement items were present (invoice now zeroed before processReplacementItems adds the extra charge)
- Fixed logReturnHistory skipping fully-returned items due to post-increment mutation on Eloquent model; effectiveQuantities captured before increment()
- Added SalesReturnHistory and SalesReturnReplacement models and migrations
- Added receipts.notes migration for audit trail written on return approval
- Added ReturnHistory tab to sales returns UI
- Added remittance improvements (request validation, UI fixes)
- Added 46 feature tests across 5 test classes covering all return scenarios, replacement item recording, receipt status preservation, and data integrity